### PR TITLE
Added `initialProperties(Material material)`

### DIFF
--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -123,6 +123,18 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
         propertiesCallback = propertiesCallback.andThen(func);
         return this;
     }
+
+    /**
+     * Replace the initial state of the block properties, without replacing or removing any modifications done via {@link #properties(NonNullUnaryOperator)}.
+     *
+     * @param material
+     *            The material of the initial properties
+     * @return this {@link BlockBuilder}
+     */
+    public BlockBuilder<T, P> initialProperties(Material material) {
+        initialProperties = () -> AbstractBlock.Properties.create(material);
+        return this;
+    }
     
     /**
      * Replace the initial state of the block properties, without replacing or removing any modifications done via {@link #properties(NonNullUnaryOperator)}.


### PR DESCRIPTION
Added alternate `initialProperties` method so you don't have to enter a color each time.

Eg.
```java
// OLD
public static final RegistryEntry<Block> TEST_BLOCK = REGISTRATE.object("test_block").block(Block::new)
    .initialProperties(Material.ROCK, Material.ROCK.getColor()).simpleItem().register();

// NEW
public static final RegistryEntry<Block> TEST_BLOCK = REGISTRATE.object("test_block").block(Block::new)
    .initialProperties(Material.ROCK).simpleItem().register();
```