### PR TITLE
readme code examples update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public static final RegistryEntry<MyStairsBlock> MY_STAIRS = REGISTRATE.object("
 
 This customized version will create a BlockItem (with its own default model and lang entry), add the block to a tag, configure the blockstate for stair properties, and add a custom localization.
 
-To get an overview of the different APIs and methods, check out the [Javadocs](https://ci.tterrag.com/job/Registrate/job/1.14/javadoc/). For more advanced usage, read the [wiki](https://github.com/tterrag1098/Registrate/wiki) (WIP).
+To get an overview of the different APIs and methods, check out the [Javadocs](https://ci.tterrag.com/job/Registrate/job/1.16/javadoc/). For more advanced usage, read the [wiki](https://github.com/tterrag1098/Registrate/wiki) (WIP).
 
 ## Project Setup
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ public static final RegistryEntry<MyBlock> MY_BLOCK = REGISTRATE.object("my_bloc
         .block(MyBlock::new)
         .register();
 ```
+Note: your block's constructor is expected to accept properties, [example here](https://github.com/tterrag1098/Registrate/blob/1.15/src/test/java/com/tterrag/registrate/test/mod/TestMod.java#L132).  
 
 This simple declaration will create a block, with a default simple blockstate, model, loot table, and lang entry. However all of these can be configured easily to use whatever custom data you may want.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using a constant field is not necessary, it can be passed around and thrown away
 Next, begin adding objects.
 
 ```java
-public static final RegistryObject<MyBlock> MY_BLOCK = REGISTRATE.object("my_block")
+public static final RegistryEntry<MyBlock> MY_BLOCK = REGISTRATE.object("my_block")
         .block(MyBlock::new)
         .register();
 ```
@@ -31,7 +31,7 @@ public static final RegistryObject<MyBlock> MY_BLOCK = REGISTRATE.object("my_blo
 This simple declaration will create a block, with a default simple blockstate, model, loot table, and lang entry. However all of these can be configured easily to use whatever custom data you may want.
 
 ```java
-public static final RegistryObject<MyStairsBlock> MY_STAIRS = REGISTRATE.object("my_block")
+public static final RegistryEntry<MyStairsBlock> MY_STAIRS = REGISTRATE.object("my_block")
         .block(MyStairsBlock::new)
             .defaultItem()
             .tag(BlockTags.STAIRS)

--- a/README.md
+++ b/README.md
@@ -22,14 +22,28 @@ Using a constant field is not necessary, it can be passed around and thrown away
 
 Next, begin adding objects.
 
+If you have a block class such as
+
+```java
+public class MyBlock extends Block {
+
+    public MyBlock(Block.Properties properties) {
+        super(properties);
+    }
+    
+    ...
+}
+```
+
+then register it like so,
+
 ```java
 public static final RegistryEntry<MyBlock> MY_BLOCK = REGISTRATE.object("my_block")
         .block(MyBlock::new)
         .register();
 ```
-Note: your block's constructor is expected to accept properties, [example here](https://github.com/tterrag1098/Registrate/blob/1.15/src/test/java/com/tterrag/registrate/test/mod/TestMod.java#L132).  
 
-This simple declaration will create a block, with a default simple blockstate, model, loot table, and lang entry. However all of these can be configured easily to use whatever custom data you may want.
+Registrate will create a block, with a default simple blockstate, model, loot table, and lang entry. However, all of these facets can be configured easily to use whatever custom data you may want. Example:
 
 ```java
 public static final RegistryEntry<MyStairsBlock> MY_STAIRS = REGISTRATE.object("my_block")


### PR DESCRIPTION
Examples were using RegistryObject instead of RegistryEntry, which led to errors because .register() returns RegistryEntry.
Added note to include a Properties param in the MyBlock constructor.