### PR TITLE
[1.19] Various quality of life changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ javadoc {
 
 publishing {
     tasks.publish.dependsOn 'build'
+    tasks.publishToMavenLocal.dependsOn 'build'
     publications {
         mavenJava(MavenPublication) {
             artifact jar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Setup gradle memory
+org.gradle.jvmargs=-Xmx3G
+org.gradle.daemon=false
+
 mod_version=1.1.x
 minecraft_version=1.19
-forge_version=41.0.17
+forge_version=41.0.94

--- a/src/generated/resources/.cache/f397dc6ed526845ef7413004504849a782f6e11e
+++ b/src/generated/resources/.cache/f397dc6ed526845ef7413004504849a782f6e11e
@@ -1,11 +1,11 @@
-// 1.19	2022-06-20T15:20:59.6081179	Registrate Provider for testmod [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.19	2022-07-18T16:06:36.5492127	Registrate Provider for testmod [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Tags (banner_pattern), Tags (worldgen/biome), Tags (cat_variant), Tags (worldgen/flat_level_generator_preset), Tags (game_events), Tags (instrument), Tags (painting_variant), Tags (point_of_interest_type), Tags (worldgen/structure), Tags (worldgen/world_preset), Blockstates, Item models, Lang (en_us/en_ud)]
 353e0134b90278ff49840165bed05cb48e7fff1b assets/testmod/blockstates/magic_item_model.json
 bc6ecd9ef8452b21567c005ab9c626c54a1beeaa assets/testmod/blockstates/testblock.json
 069fa0cc9495cbad97a129b3e39bd0bdf0599b28 assets/testmod/blockstates/testfluid.json
-df15e1d7922fd0cd781fb4ec53322b59e16fd6de assets/testmod/lang/en_ud.json
-c53f1d3957b0f1557290f2d19d14ceb7f9c51f72 assets/testmod/lang/en_us.json
+5a6966380a9641fb31f35fe8fc9964e5015c318b assets/testmod/lang/en_ud.json
+8b69c8e0e7b41eae83a4b85609d070c9ac02b079 assets/testmod/lang/en_us.json
 b3c7ac87f735c9813d09ee46f1d26c844c06353c assets/testmod/models/block/subfolder/magic_item_model.json
-e6b1a73e2228a3216085e31392b29703b4c7cda9 assets/testmod/models/block/testblock.json
+226ecfcb53fb775aa96f550dcc41bc44c026127f assets/testmod/models/block/testblock.json
 c73682ddea9998e48415b962e3c3b1d2dcc6157a assets/testmod/models/block/testfluid.json
 35c5c8cdd34da12756a7651f2da42ce019a5684a assets/testmod/models/item/magic_item_model.json
 e7327feaec0ea15c7f4f5cc4e012f4ff08284df8 assets/testmod/models/item/testblock.json
@@ -15,7 +15,6 @@ fb63fdeef603a7edf02010fc963c89e2d41931b6 assets/testmod/models/item/testitem.jso
 6cde7304ac9429b0ea7e01078b4846b1cac6a0c8 data/minecraft/tags/blocks/dragon_immune.json
 6cde7304ac9429b0ea7e01078b4846b1cac6a0c8 data/minecraft/tags/blocks/wither_immune.json
 ed4dc1c2e1c580f129c041ffd8fcfae1424366a2 data/minecraft/tags/entity_types/raiders.json
-9576a70fdda2cda7a194b93b690752f129358c3b data/minecraft/tags/fluids/water.json
 e9cec2088093803c7eb2f88bd11693cd261a8e41 data/minecraft/tags/items/beds.json
 6f59e226b42f2355554c495192d9c8a6d1908233 data/testmod/advancements/recipes/building_blocks/diamond_block_from_testblock_campfire.json
 94e422b2e38eb9270652db4d73f1daeb6e80db0b data/testmod/advancements/recipes/building_blocks/diamond_block_from_testblock_smelting.json

--- a/src/generated/resources/assets/testmod/lang/en_ud.json
+++ b/src/generated/resources/assets/testmod/lang/en_ud.json
@@ -7,6 +7,7 @@
   "enchantment.testmod.testenchantment": "ʇuǝɯʇuɐɥɔuǝʇsǝ⟘",
   "entity.testmod.testentity": "ʎʇıʇuǝʇsǝ⟘",
   "entity.testmod.testitem": "ɯǝʇıʇsǝ⟘",
+  "fluid.testmod.testfluid": "pınןɟʇsǝ⟘",
   "item.testmod.testentity_spawn_egg": "bbƎ uʍɐdS ʎʇıʇuǝʇsǝ⟘",
   "item.testmod.testitem": "ɯǝʇıʇsǝ⟘",
   "item.testmod.testitem.testextra": "¡ɔıbɐW",

--- a/src/generated/resources/assets/testmod/lang/en_us.json
+++ b/src/generated/resources/assets/testmod/lang/en_us.json
@@ -7,6 +7,7 @@
   "enchantment.testmod.testenchantment": "Testenchantment",
   "entity.testmod.testentity": "Testentity",
   "entity.testmod.testitem": "Testitem",
+  "fluid.testmod.testfluid": "Testfluid",
   "item.testmod.testentity_spawn_egg": "Testentity Spawn Egg",
   "item.testmod.testitem": "Testitem",
   "item.testmod.testitem.testextra": "Magic!",

--- a/src/generated/resources/assets/testmod/models/block/testblock.json
+++ b/src/generated/resources/assets/testmod/models/block/testblock.json
@@ -1,3 +1,4 @@
 {
-  "parent": "minecraft:block/glass"
+  "parent": "minecraft:block/glass",
+  "render_type": "minecraft:cutout"
 }

--- a/src/generated/resources/data/minecraft/tags/fluids/water.json
+++ b/src/generated/resources/data/minecraft/tags/fluids/water.json
@@ -1,6 +1,0 @@
-{
-  "values": [
-    "testmod:flowing_testfluid",
-    "testmod:testfluid"
-  ]
-}

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -38,16 +38,15 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Material;
+import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.data.loading.DatagenModLoader;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.loading.FMLEnvironment;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
 import net.minecraftforge.registries.*;
 
 import javax.annotation.Nonnull;
@@ -831,93 +830,157 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid() {
         return fluid(self());
     }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(FluidTypeFactory typeFactory) {
+        return fluid(self(), typeFactory);
+    }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(NonNullSupplier<FluidType> fluidType) {
+        return fluid(self(), fluidType);
+    }
     
     public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), stillTexture, flowingTexture);
     }
-    
-    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return fluid(self(), stillTexture, flowingTexture, attributesFactory);
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return fluid(self(), stillTexture, flowingTexture, typeFactory);
+    }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return fluid(self(), stillTexture, flowingTexture, fluidType);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            FluidFactory<T> factory) {
-        return fluid(self(), stillTexture, flowingTexture, factory);
+            FluidFactory<T> fluidFactory) {
+        return fluid(self(), stillTexture, flowingTexture, fluidFactory);
     }
-    
+
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
+        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        return fluid(self(), stillTexture, flowingTexture, typeFactory, fluidFactory);
+    }
+
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        return fluid(self(), stillTexture, flowingTexture, fluidType, fluidFactory);
     }
     
     public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name) {
         return fluid(self(), name);
     }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, FluidTypeFactory typeFactory) {
+        return fluid(self(), name, typeFactory);
+    }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, NonNullSupplier<FluidType> fluidType) {
+        return fluid(self(), name, fluidType);
+    }
     
     public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
-    
-    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory);
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, typeFactory);
+    }
+
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return fluid(self(), name, stillTexture, flowingTexture, fluidType);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            FluidFactory<T> factory) {
-        return fluid(self(), name, stillTexture, flowingTexture, factory);
+            FluidFactory<T> fluidFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, fluidFactory);
     }
-    
+
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
+        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, typeFactory, fluidFactory);
+    }
+
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, fluidType, fluidFactory);
     }
         
     public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent) {
         return fluid(parent, currentName());
     }
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, FluidTypeFactory typeFactory) {
+        return fluid(parent, currentName(), typeFactory);
+    }
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, NonNullSupplier<FluidType> fluidType) {
+        return fluid(parent, currentName(), fluidType);
+    }
     
     public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
-    
-    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory);
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory);
+    }
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType);
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            FluidFactory<T> factory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, factory);
+            FluidFactory<T> fluidFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidFactory);
     }
-    
+
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
+        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
-    
+
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType, fluidFactory);
+    }
+
     public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name) {
         return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"));
+    }
+    
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, FluidTypeFactory typeFactory) {
+        return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"), typeFactory);
+    }
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
+        return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"), fluidType);
     }
 
     public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture));
     }
     
-    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory));
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, typeFactory));
+    }
+
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, fluidType));
+    }
+
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+            FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, fluidFactory));
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            FluidFactory<T> factory) {
-        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, factory));
+        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, typeFactory, fluidFactory));
     }
-    
+
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
+        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, fluidType, fluidFactory));
     }
     
     // Menu

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -5,11 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.*;
 import com.tterrag.registrate.builders.*;
-import com.tterrag.registrate.builders.BlockEntityBuilder.BlockEntityFactory;
-import com.tterrag.registrate.builders.EnchantmentBuilder.EnchantmentFactory;
-import com.tterrag.registrate.builders.MenuBuilder.ForgeMenuFactory;
-import com.tterrag.registrate.builders.MenuBuilder.MenuFactory;
-import com.tterrag.registrate.builders.MenuBuilder.ScreenFactory;
+import com.tterrag.registrate.builders.factory.*;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateDataProvider;
 import com.tterrag.registrate.providers.RegistrateProvider;
@@ -34,7 +30,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType.EntityFactory;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.CreativeModeTab;
@@ -43,7 +38,6 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.data.loading.DatagenModLoader;
@@ -744,19 +738,19 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     // Items
     
-    public <T extends Item> ItemBuilder<S, T, S> item(NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(ItemFactory<T> factory) {
         return item(self(), factory);
     }
     
-    public <T extends Item> ItemBuilder<S, T, S> item(String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(String name, ItemFactory<T> factory) {
         return item(self(), name, factory);
     }
     
-    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, ItemFactory<T> factory) {
         return item(parent, currentName(), factory);
     }
     
-    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, String name, ItemFactory<T> factory) {
         // TODO clean this up when NonNullLazyValue is fixed better
         Supplier<? extends @NonnullType CreativeModeTab> currentTab = this.currentTab;
         return entry(name, callback -> ItemBuilder.create(self(), parent, name, callback, factory, currentTab == null ? null : currentTab::get));
@@ -764,53 +758,53 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     
     // Blocks
     
-    public <T extends Block> BlockBuilder<S, T, S> block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(BlockFactory<T> factory) {
         return block(self(), factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, BlockFactory<T> factory) {
         return block(self(), name, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, BlockFactory<T> factory) {
         return block(parent, currentName(), factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, BlockFactory<T> factory) {
         return block(parent, name, Material.STONE, factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(Material material, BlockFactory<T> factory) {
         return block(self(), material, factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, Material material, BlockFactory<T> factory) {
         return block(self(), name, material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, Material material, BlockFactory<T> factory) {
         return block(parent, currentName(), material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, Material material, BlockFactory<T> factory) {
         return entry(name, callback -> BlockBuilder.create(self(), parent, name, callback, factory, material));
     }
     
     // Entities
     
-    public <T extends Entity> EntityBuilder<S, T, S> entity(EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(self(), factory, classification);
     }
     
-    public <T extends Entity> EntityBuilder<S, T, S> entity(String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(String name, EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(self(), name, factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(parent, currentName(), factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, String name, EntityTypeFactory<T> factory, MobCategory classification) {
         return entry(name, callback -> EntityBuilder.create(self(), parent, name, callback, factory, classification));
     }
     
@@ -848,12 +842,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(self(), stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
@@ -871,12 +865,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
     }
         
@@ -894,12 +888,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
@@ -917,46 +911,46 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, factory));
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
     }
     
     // Menu
     
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
     

--- a/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.tterrag.registrate.AbstractRegistrate;
@@ -13,21 +11,25 @@ import com.tterrag.registrate.util.entry.RegistryEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiFunction;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 import net.minecraftforge.common.util.NonNullFunction;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.Arrays;
+
 /**
  * Base class which most builders should extend, instead of implementing [@link {@link Builder} directly.
  * <p>
  * Provides the most basic functionality, and some utility methods that remove the need to pass the registry class.
  *
+ * @param <O>
+ *            The type of Registrate owning the builder & compiled object.
  * @param <R>
  *            Type of the registry for the current object. This is the concrete base class that all registry entries must extend, and the type used for the forge registry itself.
  * @param <T>
@@ -39,16 +41,16 @@ import net.minecraftforge.registries.RegistryObject;
  * @see Builder
  */
 @RequiredArgsConstructor
-public abstract class AbstractBuilder<R, T extends R, P, S extends AbstractBuilder<R, T, P, S>> implements Builder<R, T, P, S> {
+public abstract class AbstractBuilder<O extends AbstractRegistrate<O>, R, T extends R, P, S extends AbstractBuilder<O, R, T, P, S>> implements Builder<O, R, T, P, S> {
 
     @Getter(onMethod_ = {@Override})
-    private final AbstractRegistrate<?> owner;
+    private final O owner;
     @Getter(onMethod_ = {@Override})
     private final P parent;
     @Getter(onMethod_ = {@Override})
     private final String name;
     @Getter(AccessLevel.PROTECTED)
-    private final BuilderCallback callback;
+    private final BuilderCallback<O> callback;
     @Getter(onMethod_ = {@Override})
     private final ResourceKey<Registry<R>> registryKey;
     

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -243,7 +243,7 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
      */
     public <I extends Item> ItemBuilder<O, I, BlockBuilder<O, T, P>> item(BlockItemFactory<? super T, ? extends I> factory) {
         return getOwner().<I, BlockBuilder<O, T, P>> item(this, getName(), p -> factory.create(getEntry(), p))
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop()) // FIXME Need a beetter API for "unsetting" providers
+                .clearData(ProviderType.LANG)
                 .model((ctx, prov) -> {
                     Optional<String> model = getOwner().getDataProvider(ProviderType.BLOCKSTATE)
                             .flatMap(p -> p.getExistingVariantBuilder(getEntry()))

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -17,12 +17,15 @@ import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Registry;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
@@ -39,7 +42,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -414,4 +419,171 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
     public BlockEntry<T> register() {
         return (BlockEntry<T>) super.register();
     }
+
+    /*
+        The following methods exist as shortcuts into Block Properties
+            Stops you needing to have long chains inside `properties()`
+            or having multiple `properties()` calls
+
+            ```
+            builder.properties(props -> props
+                .requiresCorrectToolForDrops()
+                .strength(3.5F)
+                .lightLevel(litBlockEmission(13)
+            )
+            ```
+
+            becomes
+
+            ```
+            builder.requiresCorrectToolForDrops()
+                .strength(3.5F)
+                .lightLevel(litBlockEmission(13)
+            ```
+     */
+    // region: Block Properties Wrappers
+    public final BlockBuilder<O, T, P> noCollission()
+    {
+        return properties(BlockBehaviour.Properties::noCollission);
+    }
+
+    public final BlockBuilder<O, T, P> noOcclusion()
+    {
+        return properties(BlockBehaviour.Properties::noOcclusion);
+    }
+
+    public final BlockBuilder<O, T, P> friction(float friction)
+    {
+        return properties(properties -> properties.friction(friction));
+    }
+
+    public final BlockBuilder<O, T, P> speedFactor(float speedFactor)
+    {
+        return properties(properties -> properties.speedFactor(speedFactor));
+    }
+
+    public final BlockBuilder<O, T, P> jumpFactor(float jumpFactor)
+    {
+        return properties(properties -> properties.jumpFactor(jumpFactor));
+    }
+
+    public final BlockBuilder<O, T, P> sound(SoundType soundType)
+    {
+        return properties(properties -> properties.sound(soundType));
+    }
+
+    public final BlockBuilder<O, T, P> lightLevel(ToIntFunction<BlockState> lightEmission)
+    {
+        return properties(properties -> properties.lightLevel(lightEmission));
+    }
+
+    public final BlockBuilder<O, T, P> strength(float destroyTime, float explosionResistance)
+    {
+        return properties(properties -> properties.strength(destroyTime, explosionResistance));
+    }
+
+    public final BlockBuilder<O, T, P> instabreak()
+    {
+        return properties(BlockBehaviour.Properties::instabreak);
+    }
+
+    public final BlockBuilder<O, T, P> strength(float strength)
+    {
+        return properties(properties -> properties.strength(strength));
+    }
+
+    public final BlockBuilder<O, T, P> randomTicks()
+    {
+        return properties(BlockBehaviour.Properties::randomTicks);
+    }
+
+    public final BlockBuilder<O, T, P> dynamicShape()
+    {
+        return properties(BlockBehaviour.Properties::dynamicShape);
+    }
+
+    public final BlockBuilder<O, T, P> noLootTable()
+    {
+        return properties(BlockBehaviour.Properties::noLootTable);
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla block reasons, should never be used with custom modded blocks. Modded should use {@link #lootFrom(Supplier)}
+     */
+    @Deprecated
+    public final BlockBuilder<O, T, P> dropsLike(Block block)
+    {
+        return properties(properties -> properties.dropsLike(block));
+    }
+
+    public final BlockBuilder<O, T, P> lootFrom(Supplier<? extends Block> block)
+    {
+        return properties(properties -> properties.lootFrom(block));
+    }
+
+    public final BlockBuilder<O, T, P> air()
+    {
+        return properties(BlockBehaviour.Properties::air);
+    }
+
+    public final BlockBuilder<O, T, P> isValidSpawn(BlockBehaviour.StateArgumentPredicate<EntityType<?>> predicate)
+    {
+        return properties(properties -> properties.isValidSpawn(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> isRedstoneConductor(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isRedstoneConductor(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> isSuffocating(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isSuffocating(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> isViewBlocking(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isViewBlocking(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> hasPostProcess(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.hasPostProcess(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> emissiveRendering(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.emissiveRendering(predicate));
+    }
+
+    public final BlockBuilder<O, T, P> requiresCorrectToolForDrops()
+    {
+        return properties(BlockBehaviour.Properties::requiresCorrectToolForDrops);
+    }
+
+    public final BlockBuilder<O, T, P> color(MaterialColor materialColor)
+    {
+        return properties(properties -> properties.color(materialColor));
+    }
+
+    public final BlockBuilder<O, T, P> destroyTime(float destroyTime)
+    {
+        return properties(properties -> properties.destroyTime(destroyTime));
+    }
+
+    public final BlockBuilder<O, T, P> explosionResistance(float explosionResistance)
+    {
+        return properties(properties -> properties.explosionResistance(explosionResistance));
+    }
+
+    public final BlockBuilder<O, T, P> offsetType(BlockBehaviour.OffsetType offsetType)
+    {
+        return properties(properties -> properties.offsetType(offsetType));
+    }
+
+    public final BlockBuilder<O, T, P> offsetType(Function<BlockState, BlockBehaviour.OffsetType> offsetType)
+    {
+        return properties(properties -> properties.offsetType(offsetType));
+    }
+    // endregion
 }

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -1,13 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
@@ -29,15 +21,24 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.registries.RegistryObject;
 
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
  * A builder for block entities, allows for customization of the valid blocks.
- * 
+ *
+ * @param <O>
+ *            The type of Registrate owning the builder & compiled object.
  * @param <T>
  *            The type of block entity being built
  * @param <P>
  *            Parent object type
  */
-public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilder<BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<T, P>> {
+public class BlockEntityBuilder<O extends AbstractRegistrate<O>, T extends BlockEntity, P> extends AbstractBuilder<O, BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<O, T, P>> {
 
     public interface BlockEntityFactory<T extends BlockEntity> {
 
@@ -66,7 +67,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            Factory to create the block entity
      * @return A new {@link BlockEntityBuilder} with reasonable default data generators.
      */
-    public static <T extends BlockEntity, P> BlockEntityBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends BlockEntity, P> BlockEntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, BlockEntityFactory<T> factory) {
         return new BlockEntityBuilder<>(owner, parent, name, callback, factory);
     }
 
@@ -75,7 +76,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
     @Nullable
     private NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer;
 
-    protected BlockEntityBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
+    protected BlockEntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, BlockEntityFactory<T> factory) {
         super(owner, parent, name, callback, Registry.BLOCK_ENTITY_TYPE_REGISTRY);
         this.factory = factory;
     }
@@ -87,7 +88,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A supplier for the block to add at registration time
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> validBlock(NonNullSupplier<? extends Block> block) {
+    public BlockEntityBuilder<O, T, P> validBlock(NonNullSupplier<? extends Block> block) {
         validBlocks.add(block);
         return this;
     }
@@ -100,7 +101,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      * @return this {@link BlockEntityBuilder}
      */
     @SafeVarargs
-    public final BlockEntityBuilder<T, P> validBlocks(NonNullSupplier<? extends Block>... blocks) {
+    public final BlockEntityBuilder<O, T, P> validBlocks(NonNullSupplier<? extends Block>... blocks) {
         Arrays.stream(blocks).forEach(this::validBlock);
         return this;
     }
@@ -115,7 +116,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A (server safe) supplier to an {@link Function} that will provide this block entity's renderer given the renderer dispatcher
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer) {
+    public BlockEntityBuilder<O, T, P> renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer) {
         if (this.renderer == null) { // First call only
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerRenderer);
         }

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -11,13 +11,13 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraft.core.Registry;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import javax.annotation.Nullable;
@@ -29,9 +29,7 @@ import java.util.function.Supplier;
 
 /**
  * A builder for block entities, allows for customization of the valid blocks.
- *
- * @param <O>
- *            The type of Registrate owning the builder & compiled object.
+ * 
  * @param <T>
  *            The type of block entity being built
  * @param <P>
@@ -70,7 +68,7 @@ public class BlockEntityBuilder<O extends AbstractRegistrate<O>, T extends Block
     private NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer;
 
     protected BlockEntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, BlockEntityFactory<T> factory) {
-        super(owner, parent, name, callback, Registry.BLOCK_ENTITY_TYPE_REGISTRY);
+        super(owner, parent, name, callback, ForgeRegistries.Keys.BLOCK_ENTITY_TYPES);
         this.factory = factory;
     }
     

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.BlockEntityFactory;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -10,12 +11,10 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -39,12 +38,6 @@ import java.util.function.Supplier;
  *            Parent object type
  */
 public class BlockEntityBuilder<O extends AbstractRegistrate<O>, T extends BlockEntity, P> extends AbstractBuilder<O, BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<O, T, P>> {
-
-    public interface BlockEntityFactory<T extends BlockEntity> {
-
-        public T create(BlockEntityType<T> type, BlockPos pos, BlockState state);
-
-    }
 
     /**
      * Create a new {@link BlockEntityBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.

--- a/src/main/java/com/tterrag/registrate/builders/Builder.java
+++ b/src/main/java/com/tterrag/registrate/builders/Builder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.function.Function;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
@@ -14,15 +12,18 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
-import net.minecraftforge.registries.RegistryManager;
 import net.minecraftforge.registries.RegistryObject;
+
+import java.util.function.Function;
 
 /**
  * A Builder creates registry entries. A Builder instance has a constant name which will be used for the resultant object, they cannot be reused for different names. It holds a parent object that will
  * be returned from some final methods.
  * <p>
  * When a builder is completed via {@link #register()} or {@link #build()}, the object will be lazily registered (through the owning {@link AbstractRegistrate} object).
- * 
+ *
+ * @param <O>
+ *            The type of Registrate owning the builder & compiled object.
  * @param <R>
  *            Type of the registry for the current object. This is the concrete base class that all registry entries must extend, and the type used for the forge registry itself.
  * @param <T>
@@ -32,7 +33,7 @@ import net.minecraftforge.registries.RegistryObject;
  * @param <S>
  *            Self type
  */
-public interface Builder<R, T extends R, P, S extends Builder<R, T, P, S>> extends NonNullSupplier<RegistryEntry<T>> {
+public interface Builder<O extends AbstractRegistrate<O>, R, T extends R, P, S extends Builder<O, R, T, P, S>> extends NonNullSupplier<RegistryEntry<T>> {
 
     /**
      * Complete the current entry, and return the {@link RegistryEntry} that will supply the built entry once it is available. The builder can be used afterwards, and changes made will reflect the
@@ -47,7 +48,7 @@ public interface Builder<R, T extends R, P, S extends Builder<R, T, P, S>> exten
      * 
      * @return the owner {@link AbstractRegistrate}
      */
-    AbstractRegistrate<?> getOwner();
+    O getOwner();
 
     /**
      * The parent object.
@@ -202,7 +203,7 @@ public interface Builder<R, T extends R, P, S extends Builder<R, T, P, S>> exten
      * @return the {@link Builder} returned by the given function
      */
     @SuppressWarnings("unchecked")
-    default <R2, T2 extends R2, P2, S2 extends Builder<R2, T2, P2, S2>> S2 transform(NonNullFunction<S, S2> func) {
+    default <O2 extends AbstractRegistrate<O2>, R2, T2 extends R2, P2, S2 extends Builder<O2, R2, T2, P2, S2>> S2 transform(NonNullFunction<S, S2> func) {
         return func.apply((S) this);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/Builder.java
+++ b/src/main/java/com/tterrag/registrate/builders/Builder.java
@@ -120,6 +120,20 @@ public interface Builder<O extends AbstractRegistrate<O>, R, T extends R, P, S e
     }
 
     /**
+     * Clear the data provider callback for this entry for the given provider type
+     *
+     * @param <D>
+     *            The type of provider
+     * @param type
+     *            The {@link ProviderType} for the desired provider
+     * @return this builder
+     */
+    default <D extends RegistrateProvider> S clearData(ProviderType<? extends D> type)
+    {
+        return setData(type, NonNullBiConsumer.noop());
+    }
+
+    /**
      * Add a data provider callback which will be invoked when the provider of the given type executes.
      * <p>
      * Calling this multiple times for the same type will <em>not</em> overwrite an existing callback.

--- a/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
+++ b/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
@@ -13,7 +13,7 @@ import net.minecraftforge.registries.RegistryObject;
  * A callback passed to {@link Builder builders} from the owning {@link AbstractRegistrate} which will add a registration for the built entry that lazily creates and registers it.
  */
 @FunctionalInterface
-public interface BuilderCallback {
+public interface BuilderCallback<O extends AbstractRegistrate<O>> {
 
     /**
      * Accept a built entry, to later be constructed and registered.
@@ -34,7 +34,7 @@ public interface BuilderCallback {
      *            A {@link NonNullFunction} which accepts the entry delegate and returns a {@link RegistryEntry} wrapper
      * @return A {@link RegistryEntry} that will supply the registered entry
      */
-    <R, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
+    <R, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
 
     /**
      * Accept a built entry, to later be constructed and registered. Uses the default {@link RegistryEntry#RegistryEntry(AbstractRegistrate, RegistryObject) RegistryEntry factory}.
@@ -53,7 +53,7 @@ public interface BuilderCallback {
      *            A {@link NonNullSupplier} that will create the entry
      * @return A {@link RegistryEntry} that will supply the registered entry
      */
-    default <R, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory) {
+    default <R, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory) {
         return accept(name, type, builder, factory, delegate -> new RegistryEntry<>(builder.getOwner(), delegate));
     }
 }

--- a/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
+++ b/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
@@ -36,6 +36,7 @@ public interface BuilderCallback<O extends AbstractRegistrate<O>> {
      */
     <R, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
 
+
     /**
      * Accept a built entry, to later be constructed and registered. Uses the default {@link RegistryEntry#RegistryEntry(AbstractRegistrate, RegistryObject) RegistryEntry factory}.
      * 

--- a/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
@@ -1,8 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-import java.util.EnumSet;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
@@ -13,6 +10,9 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 
+import java.util.Arrays;
+import java.util.EnumSet;
+
 /**
  * A builder for enchantments, allows for customization of the {@link Enchantment.Rarity enchantment rarity} and {@link EquipmentSlot equipment slots}, and configuration of data associated with
  * enchantments (lang).
@@ -22,7 +22,7 @@ import net.minecraft.world.item.enchantment.EnchantmentCategory;
  * @param <P>
  *            Parent object type
  */
-public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilder<Enchantment, T, P, EnchantmentBuilder<T, P>> {
+public class EnchantmentBuilder<O extends AbstractRegistrate<O>, T extends Enchantment, P> extends AbstractBuilder<O, Enchantment, T, P, EnchantmentBuilder<O, T, P>> {
 
     @FunctionalInterface
     public interface EnchantmentFactory<T extends Enchantment> {
@@ -56,7 +56,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            Factory to create the enchantment
      * @return A new {@link EnchantmentBuilder} with reasonable default data generators.
      */
-    public static <T extends Enchantment, P> EnchantmentBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends Enchantment, P> EnchantmentBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         return new EnchantmentBuilder<>(owner, parent, name, callback, type, factory)
                 .defaultLang();
     }
@@ -68,7 +68,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
 
     private final EnchantmentFactory<T> factory;
 
-    protected EnchantmentBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    protected EnchantmentBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         super(owner, parent, name, callback, Registry.ENCHANTMENT_REGISTRY);
         this.factory = factory;
         this.type = type;
@@ -81,7 +81,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            The rarity to assign
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> rarity(Enchantment.Rarity rarity) {
+    public EnchantmentBuilder<O, T, P> rarity(Enchantment.Rarity rarity) {
         this.rarity = rarity;
         return this;
     }
@@ -91,7 +91,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      * 
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> addArmorSlots() {
+    public EnchantmentBuilder<O, T, P> addArmorSlots() {
         return addSlots(EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET);
     }
 
@@ -102,7 +102,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            The slots to add
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> addSlots(EquipmentSlot... slots) {
+    public EnchantmentBuilder<O, T, P> addSlots(EquipmentSlot... slots) {
         this.slots.addAll(Arrays.asList(slots));
         return this;
     }
@@ -113,7 +113,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      * 
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> defaultLang() {
+    public EnchantmentBuilder<O, T, P> defaultLang() {
         return lang(Enchantment::getDescriptionId);
     }
 
@@ -124,7 +124,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            A localized English name
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> lang(String name) {
+    public EnchantmentBuilder<O, T, P> lang(String name) {
         return lang(Enchantment::getDescriptionId, name);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.EnchantmentFactory;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
@@ -23,12 +24,6 @@ import java.util.EnumSet;
  *            Parent object type
  */
 public class EnchantmentBuilder<O extends AbstractRegistrate<O>, T extends Enchantment, P> extends AbstractBuilder<O, Enchantment, T, P, EnchantmentBuilder<O, T, P>> {
-
-    @FunctionalInterface
-    public interface EnchantmentFactory<T extends Enchantment> {
-        
-        T create(Enchantment.Rarity rarity, EnchantmentCategory type, EquipmentSlot... slots);
-    }
 
     /**
      * Create a new {@link EnchantmentBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.

--- a/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
@@ -6,10 +6,10 @@ import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
 
-import net.minecraft.core.Registry;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -64,7 +64,7 @@ public class EnchantmentBuilder<O extends AbstractRegistrate<O>, T extends Encha
     private final EnchantmentFactory<T> factory;
 
     protected EnchantmentBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
-        super(owner, parent, name, callback, Registry.ENCHANTMENT_REGISTRY);
+        super(owner, parent, name, callback, ForgeRegistries.Keys.ENCHANTMENTS);
         this.factory = factory;
         this.type = type;
     }

--- a/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
@@ -17,7 +17,6 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
-import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.*;
@@ -34,6 +33,7 @@ import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.PlayMessages;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import javax.annotation.Nullable;
@@ -93,7 +93,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
     private boolean attributesConfigured, spawnConfigured; // TODO make this more reuse friendly
     
     protected EntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EntityTypeFactory<T> factory, MobCategory classification) {
-        super(owner, parent, name, callback, Registry.ENTITY_TYPE_REGISTRY);
+        super(owner, parent, name, callback, ForgeRegistries.Keys.ENTITY_TYPES);
         this.builder = () -> EntityType.Builder.of(factory, classification);
     }
 
@@ -299,6 +299,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
     public EntityEntry<T> register() {
         return (EntityEntry<T>) super.register();
     }
+
 
     /*
         The following methods exist as shortcuts into EntityType.Builder

--- a/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.EntityTypeFactory;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
@@ -76,7 +77,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
      *            The {@link MobCategory} of the entity
      * @return A new {@link EntityBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Entity, P> EntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EntityType.EntityFactory<T> factory,
+    public static <O extends AbstractRegistrate<O>, T extends Entity, P> EntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EntityTypeFactory<T> factory,
             MobCategory classification) {
         return new EntityBuilder<>(owner, parent, name, callback, factory, classification)
                 .defaultLang();
@@ -91,7 +92,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
     
     private boolean attributesConfigured, spawnConfigured; // TODO make this more reuse friendly
     
-    protected EntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EntityType.EntityFactory<T> factory, MobCategory classification) {
+    protected EntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EntityTypeFactory<T> factory, MobCategory classification) {
         super(owner, parent, name, callback, Registry.ENTITY_TYPE_REGISTRY);
         this.builder = () -> EntityType.Builder.of(factory, classification);
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -4,20 +4,19 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.builders.factory.FluidFactory;
+import com.tterrag.registrate.builders.factory.FluidTypeFactory;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
+import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.NonNullBiFunction;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import com.tterrag.registrate.util.nullness.*;
 
 import net.minecraft.Util;
-import net.minecraft.core.Registry;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
@@ -27,39 +26,51 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Fluid;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-/**
- * A builder for fluids, allows for customization of the {@link ForgeFlowingFluid.Properties} and {@link FluidAttributes}, and creation of the source variant, fluid block, and bucket item, as well as
- * data associated with fluids (tags, etc.).
- * 
- * @param <T>
- *            The type of fluid being built
- * @param <P>
- *            Parent object type
- */
 public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> extends AbstractBuilder<O, Fluid, T, P, FluidBuilder<O, T, P>> {
-    
-    private static class Builder extends FluidAttributes.Builder {
-        
-        protected Builder(ResourceLocation still, ResourceLocation flowing, BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-            super(still, flowing, attributesFactory);
-        }
+
+    /**
+     * Create a new {@link FluidBuilder} and configure data. The created builder will use a default ({@link FluidType}) and fluid class ({@link ForgeFlowingFluid.Flowing}).
+     *
+     * @param <P>
+     *            Parent object type
+     * @param owner
+     *            The owning {@link AbstractRegistrate} object
+     * @param parent
+     *            The parent object
+     * @param name
+     *            Name of the entry being built
+     * @param callback
+     *            A callback used to actually register the built entry
+     * @param stillTexture
+     *            The texture to use for still fluids
+     * @param flowingTexture
+     *            The texture to use for flowing fluids
+     * @return A new {@link FluidBuilder} with reasonable default data generators.
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, FluidFactory)
+     */
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, ForgeFlowingFluid.Flowing::new);
     }
 
     /**
-     * Create a new {@link FluidBuilder} and configure data. The created builder will use the default attributes class ({@link FluidAttributes}) and fluid class ({@link ForgeFlowingFluid.Flowing}).
-     * 
+     * Create a new {@link FluidBuilder} and configure data. The created builder will use a default fluid class ({@link ForgeFlowingFluid.Flowing}).
+     *
      * @param <P>
      *            Parent object type
      * @param owner
@@ -72,18 +83,20 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      *            A callback used to actually register the built entry
      * @param stillTexture
      *            The texture to use for still fluids
+     * @param typeFactory
+     *            A factory that creates the fluid type
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, FluidFactory)
      */
-    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null);
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, FluidFactory.FLOWING);
     }
-    
+
     /**
-     * Create a new {@link FluidBuilder} and configure data. The created builder will use the default fluid class ({@link ForgeFlowingFluid.Flowing}).
-     * 
+     * Create a new {@link FluidBuilder} and configure data. The created builder will use a default fluid class ({@link ForgeFlowingFluid.Flowing}).
+     *
      * @param <P>
      *            Parent object type
      * @param owner
@@ -96,21 +109,20 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      *            A callback used to actually register the built entry
      * @param stillTexture
      *            The texture to use for still fluids
+     * @param fluidType
+     *            An existing and registered fluid type.
      * @param flowingTexture
      *            The texture to use for flowing fluids
-     * @param attributesFactory
-     *            A factory that creates the fluid attributes instance
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, FluidFactory)
      */
-    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, FluidFactory.FLOWING);
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, FluidFactory.FLOWING);
     }
-    
+
     /**
-     * Create a new {@link FluidBuilder} and configure data. The created builder will use the default attributes class ({@link FluidAttributes}).
-     * 
+     * Create a new {@link FluidBuilder} and configure data. The created builder will use a default ({@link FluidType}) and fluid class ({@link ForgeFlowingFluid.Flowing}).
+     *
      * @param <T>
      *            The type of the builder
      * @param <P>
@@ -127,16 +139,15 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      *            The texture to use for still fluids
      * @param flowingTexture
      *            The texture to use for flowing fluids
-     * @param factory
+     * @param fluidFactory
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            FluidFactory<T> factory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
+            FluidFactory<T> fluidFactory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, fluidFactory);
     }
-    
+
     /**
      * Create a new {@link FluidBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
      * <p>
@@ -146,9 +157,8 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * <li>A default {@link ForgeFlowingFluid.Source source fluid} (via {@link #defaultSource})</li>
      * <li>A default block for the fluid, with its own default blockstate and model that configure the particle texture (via {@link #defaultBlock()})</li>
      * <li>A default bucket item, that uses a simple generated item model with a texture of the same name as this fluid (via {@link #defaultBucket()})</li>
-     * <li>Tagged with {@link FluidTags#WATER}</li>
      * </ul>
-     * 
+     *
      * @param <T>
      *            The type of the builder
      * @param <P>
@@ -165,100 +175,188 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      *            The texture to use for still fluids
      * @param flowingTexture
      *            The texture to use for flowing fluids
-     * @param attributesFactory
-     *            A factory that creates the fluid attributes instance
-     * @param factory
+     * @param typeFactory
+     *            A factory that creates the fluid type
+     * @param fluidFactory
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
-                .defaultLang().defaultSource().defaultBlock().defaultBucket()
-                .tag(FluidTags.WATER);
-
+        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, fluidFactory)
+            .defaultLang().defaultSource().defaultBlock().defaultBucket();
         return ret;
     }
 
-    private final ResourceLocation stillTexture;
-    private final String sourceName;
-    private final String bucketName;
-    private final NonNullSupplier<FluidAttributes.Builder> attributes;
-    private final FluidFactory<T> factory;
+    /**
+     * Create a new {@link FluidBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
+     * <p>
+     * The fluid will be assigned the following data:
+     * <ul>
+     * <li>The default translation (via {@link #defaultLang()})</li>
+     * <li>A default {@link ForgeFlowingFluid.Source source fluid} (via {@link #defaultSource})</li>
+     * <li>A default block for the fluid, with its own default blockstate and model that configure the particle texture (via {@link #defaultBlock()})</li>
+     * <li>A default bucket item, that uses a simple generated item model with a texture of the same name as this fluid (via {@link #defaultBucket()})</li>
+     * </ul>
+     *
+     * @param <T>
+     *            The type of the builder
+     * @param <P>
+     *            Parent object type
+     * @param owner
+     *            The owning {@link AbstractRegistrate} object
+     * @param parent
+     *            The parent object
+     * @param name
+     *            Name of the entry being built
+     * @param callback
+     *            A callback used to actually register the built entry
+     * @param stillTexture
+     *            The texture to use for still fluids
+     * @param flowingTexture
+     *            The texture to use for flowing fluids
+     * @param fluidType
+     *            An existing and registered fluid type
+     * @param fluidFactory
+     *            A factory that creates the flowing fluid
+     * @return A new {@link FluidBuilder} with reasonable default data generators.
+     */
+    public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, fluidFactory)
+                .defaultLang().defaultSource().defaultBlock().defaultBucket();
+        return ret;
+    }
+
+    private final String sourceName, bucketName;
+
+    private final ResourceLocation stillTexture, flowingTexture;
+    private final FluidFactory<T> fluidFactory;
+
+    @Nullable
+    private final NonNullSupplier<FluidType> fluidType;
 
     @Nullable
     private Boolean defaultSource, defaultBlock, defaultBucket;
 
-    private NonNullConsumer<FluidAttributes.Builder> attributesCallback = $ -> {};
-    private NonNullConsumer<ForgeFlowingFluid.Properties> properties;
+    private NonNullConsumer<FluidType.Properties> typeProperties = $ -> {};
+
+    private NonNullConsumer<ForgeFlowingFluid.Properties> fluidProperties;
+
+    private @Nullable Supplier<RenderType> layer = null;
+
+    private boolean registerType;
+
     @Nullable
     private NonNullSupplier<? extends ForgeFlowingFluid> source;
-    private List<TagKey<Fluid>> tags = new ArrayList<>();
+    private final List<TagKey<Fluid>> tags = new ArrayList<>();
 
-    protected FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
-        super(owner, parent, "flowing_" + name, callback, Registry.FLUID_REGISTRY);
-        this.stillTexture = stillTexture;
+    public FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        super(owner, parent, "flowing_" + name, callback, ForgeRegistries.Keys.FLUIDS);
         this.sourceName = name;
         this.bucketName = name + "_bucket";
-        this.attributes = () -> attributesFactory == null ? FluidAttributes.builder(stillTexture, flowingTexture) : new Builder(stillTexture, flowingTexture, attributesFactory);
-        this.factory = factory;
-        
+        this.stillTexture = stillTexture;
+        this.flowingTexture = flowingTexture;
+        this.fluidFactory = fluidFactory;
+        this.fluidType = NonNullSupplier.lazy(() -> typeFactory.create(makeTypeProperties(), this.stillTexture, this.flowingTexture));
+        this.registerType = true;
+
         String bucketName = this.bucketName;
-        this.properties = p -> p.bucket(() -> owner.get(bucketName, Registry.ITEM_REGISTRY).get())
-                .block(() -> owner.<Block, LiquidBlock>get(name, Registry.BLOCK_REGISTRY).get());
+        this.fluidProperties = p -> p.bucket(() -> owner.get(bucketName, ForgeRegistries.Keys.ITEMS).get())
+            .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
     }
-    
+
+    public FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        super(owner, parent, "flowing_" + name, callback, ForgeRegistries.Keys.FLUIDS);
+        this.sourceName = name;
+        this.bucketName = name + "_bucket";
+        this.stillTexture = stillTexture;
+        this.flowingTexture = flowingTexture;
+        this.fluidFactory = fluidFactory;
+        this.fluidType = fluidType;
+        this.registerType = false; // Don't register if we have a fluid from outside.
+
+        String bucketName = this.bucketName;
+        this.fluidProperties = p -> p.bucket(() -> owner.get(bucketName, ForgeRegistries.Keys.ITEMS).get())
+                .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
+    }
+
     /**
-     * Modify the attributes of the fluid. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
+     * Modify the properties of the fluid type. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
      * different operations.
-     * 
+     *
      * @param cons
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<O, T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
-        attributesCallback = attributesCallback.andThen(cons);
-        return this;
-    }
-    
-    /**
-     * Modify the properties of the fluid. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
-     * different operations.
-     *
-     * @param cons
-     *            The action to perform on the properties
-     * @return this {@link FluidBuilder}
-     */
-    public FluidBuilder<O, T, P> properties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
-        properties = properties.andThen(cons);
+    public FluidBuilder<O, T, P> properties(NonNullConsumer<FluidType.Properties> cons) {
+        typeProperties = typeProperties.andThen(cons);
         return this;
     }
 
     /**
-     * Assign the default translation, as specified by {@link RegistrateLangProvider#getAutomaticName(NonNullSupplier, net.minecraft.resources.ResourceKey)}. This is the default, so it is generally
-     * not necessary to call, unless for undoing previous changes.
-     * 
+     * Modify the properties of the flowing fluid. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
+     * different operations.
+     *
+     * @param cons
+     *            The action to perform on the attributes
+     * @return this {@link FluidBuilder}
+     */
+    public FluidBuilder<O, T, P> fluidProperties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
+        fluidProperties = fluidProperties.andThen(cons);
+        return this;
+    }
+
+    /**
+     * Assign the default translation, as specified by {@link RegistrateLangProvider#toEnglishName(String)}. This is the default, so it is generally not necessary to call, unless for
+     * undoing previous changes.
+     *
      * @return this {@link FluidBuilder}
      */
     public FluidBuilder<O, T, P> defaultLang() {
-        return lang(f -> f.getAttributes().getTranslationKey(), RegistrateLangProvider.toEnglishName(sourceName));
+        return lang(f -> f.getFluidType().getDescriptionId(), RegistrateLangProvider.toEnglishName(sourceName));
     }
 
     /**
      * Set the translation for this fluid.
-     * 
+     *
      * @param name
      *            A localized English name
      * @return this {@link FluidBuilder}
      */
     public FluidBuilder<O, T, P> lang(String name) {
-        return lang(f -> f.getAttributes().getTranslationKey(), name);
+        return lang(f -> f.getFluidType().getDescriptionId(), name);
+    }
+
+    @SuppressWarnings("deprecation")
+    public FluidBuilder<O, T, P> renderType(Supplier<RenderType> layer) {
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+            Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(layer.get()), "Invalid render type: " + layer);
+        });
+
+        if (this.layer == null) {
+            onRegister(this::registerRenderType);
+        }
+        this.layer = layer;
+        return this;
+    }
+
+    @SuppressWarnings("deprecation")
+    protected void registerRenderType(T entry) {
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+            OneTimeEventReceiver.addModListener(FMLClientSetupEvent.class, $ -> {
+                if (this.layer != null) {
+                    RenderType layer = this.layer.get();
+                    ItemBlockRenderTypes.setRenderLayer(entry, layer);
+                    ItemBlockRenderTypes.setRenderLayer(getSource(), layer);
+                }
+            });
+        });
     }
 
     /**
      * Create a standard {@link ForgeFlowingFluid.Source} for this fluid which will be built and registered along with this fluid.
-     * 
+     *
      * @return this {@link FluidBuilder}
      * @see #source(NonNullFunction)
      * @throws IllegalStateException
@@ -274,7 +372,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a {@link ForgeFlowingFluid} for this fluid, which is created by the given factory, and which will be built and registered along with this fluid.
-     * 
+     *
      * @param factory
      *            A factory for the fluid, which accepts the properties and returns a new fluid
      * @return this {@link FluidBuilder}
@@ -287,7 +385,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a standard {@link LiquidBlock} for this fluid, building it immediately, and not allowing for further configuration.
-     * 
+     *
      * @return this {@link FluidBuilder}
      * @see #block()
      * @throws IllegalStateException
@@ -303,7 +401,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a standard {@link LiquidBlock} for this fluid, and return the builder for it so that further customization can be done.
-     * 
+     *
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
     public BlockBuilder<O, LiquidBlock, FluidBuilder<O, T, P>> block() {
@@ -312,7 +410,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a {@link LiquidBlock} for this fluid, which is created by the given factory, and return the builder for it so that further customization can be done.
-     * 
+     *
      * @param <B>
      *            The type of the block
      * @param factory
@@ -326,14 +424,10 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         this.defaultBlock = false;
         NonNullSupplier<T> supplier = asSupplier();
         return getOwner().<B, FluidBuilder<O, T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
-                .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noLootTable())
-                .properties(p -> {
-                    // TODO is this ok?
-                    FluidAttributes attrs = this.attributes.get().build(Fluids.WATER);
-                    return p.lightLevel($ -> attrs.getLuminosity());
-                })
-                .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(sourceName)
-                                .texture("particle", stillTexture)));
+            .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noLootTable())
+            .properties(p -> p.lightLevel(blockState -> fluidType.get().getLightLevel()))
+            .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(sourceName)
+                .texture("particle", stillTexture)));
     }
 
     @Beta
@@ -347,7 +441,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a standard {@link BucketItem} for this fluid, building it immediately, and not allowing for further configuration.
-     * 
+     *
      * @return this {@link FluidBuilder}
      * @see #bucket()
      * @throws IllegalStateException
@@ -363,7 +457,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a standard {@link BucketItem} for this fluid, and return the builder for it so that further customization can be done.
-     * 
+     *
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
     public ItemBuilder<O, BucketItem, FluidBuilder<O, T, P>> bucket() {
@@ -372,7 +466,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Create a {@link BucketItem} for this fluid, which is created by the given factory, and return the builder for it so that further customization can be done.
-     * 
+     *
      * @param <I>
      *            The type of the bucket item
      * @param factory
@@ -385,12 +479,13 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         }
         this.defaultBucket = false;
         NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
+        // TODO: Can we find a way to circumvent this limitation?
         if (source == null) {
             throw new IllegalStateException("Cannot create a bucket before creating a source block");
         }
         return getOwner().<I, FluidBuilder<O, T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
-                .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
-                .model((ctx, prov) -> prov.generated(ctx::getEntry, new ResourceLocation(getOwner().getModid(), "item/" + bucketName)));
+            .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
+            .model((ctx, prov) -> prov.generated(ctx::getEntry, new ResourceLocation(getOwner().getModid(), "item/" + bucketName)));
     }
 
     @Beta
@@ -404,7 +499,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Assign {@link TagKey}{@code s} to this fluid and its source fluid. Multiple calls will add additional tags.
-     * 
+     *
      * @param tags
      *            The tags to assign
      * @return this {@link FluidBuilder}
@@ -414,7 +509,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         FluidBuilder<O, T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
             ret.getOwner().<RegistrateTagsProvider<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
-                    prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
+                prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
         }
         this.tags.addAll(Arrays.asList(tags));
         return ret;
@@ -422,7 +517,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     /**
      * Remove {@link TagKey}{@code s} from this fluid and its source fluid. Multiple calls will remove additional tags.
-     * 
+     *
      * @param tags
      *            The tags to remove
      * @return this {@link FluidBuilder}
@@ -438,41 +533,57 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         Preconditions.checkNotNull(source, "Fluid has no source block: " + sourceName);
         return source.get();
     }
-    
+
     private ForgeFlowingFluid.Properties makeProperties() {
-        FluidAttributes.Builder attributes = this.attributes.get();
-        RegistryEntry<Block> block = getOwner().getOptional(sourceName, Registry.BLOCK_REGISTRY);
-        attributesCallback.accept(attributes);
+        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
+        ForgeFlowingFluid.Properties ret = new ForgeFlowingFluid.Properties(fluidType, source == null ? null : source::get, asSupplier());
+        fluidProperties.accept(ret);
+        return ret;
+    }
+
+    private FluidType.Properties makeTypeProperties() {
+        FluidType.Properties properties = FluidType.Properties.create();
+        RegistryEntry<Block> block = getOwner().getOptional(sourceName, ForgeRegistries.Keys.BLOCKS);
+        this.typeProperties.accept(properties);
+
         // Force the translation key after the user callback runs
         // This is done because we need to remove the lang data generator if using the block key,
         // and if it was possible to undo this change, it might result in the user translation getting
         // silently lost, as there's no good way to check whether the translation key was changed.
         // TODO improve this?
         if (block.isPresent()) {
-            attributes.translationKey(block.get().getDescriptionId());
-            clearData(ProviderType.LANG);
+            properties.descriptionId(block.get().getDescriptionId());
+            setData(ProviderType.LANG, NonNullBiConsumer.noop());
         } else {
-            attributes.translationKey(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
+            properties.descriptionId(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
         }
-        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
-        ForgeFlowingFluid.Properties ret = new ForgeFlowingFluid.Properties(source == null ? null : source::get, asSupplier(), attributes);
-        properties.accept(ret);
-        return ret;
+
+        return properties;
     }
 
     @Override
     protected T createEntry() {
-        return factory.create(makeProperties());
+        return fluidFactory.create(makeProperties());
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * Additionally registers the source fluid.
+     * Additionally registers the source fluid and the fluid type (if constructed).
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public FluidEntry<T> register() {
+        // Check the fluid has a type.
+        if (this.fluidType != null) {
+            // Register the type.
+            if (this.registerType) {
+                getOwner().simple(this, this.sourceName, ForgeRegistries.Keys.FLUID_TYPES, this.fluidType);
+            }
+        } else {
+            throw new IllegalStateException("Fluid must have a type: " + getName());
+        }
+
         if (defaultSource == Boolean.TRUE) {
             source(ForgeFlowingFluid.Source::new);
         }
@@ -482,17 +593,39 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         if (defaultBucket == Boolean.TRUE) {
             bucket().register();
         }
+
         NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
         if (source != null) {
-            getCallback().accept(sourceName, Registry.FLUID_REGISTRY, (FluidBuilder) this, source::get);
+            getCallback().accept(sourceName, ForgeRegistries.Keys.FLUIDS, (FluidBuilder) this, source::get);
         } else {
             throw new IllegalStateException("Fluid must have a source version: " + getName());
         }
+
         return (FluidEntry<T>) super.register();
     }
 
     @Override
     protected RegistryEntry<T> createEntryWrapper(RegistryObject<T> delegate) {
         return new FluidEntry<>(getOwner(), delegate);
+    }
+
+    // Basic default fluid type implementation.
+    private static FluidType defaultFluidType(FluidType.Properties properties, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+        return new FluidType(properties) {
+            @Override
+            public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
+                consumer.accept(new IClientFluidTypeExtensions() {
+                    @Override
+                    public ResourceLocation getStillTexture() {
+                        return stillTexture;
+                    }
+
+                    @Override
+                    public ResourceLocation getFlowingTexture() {
+                        return flowingTexture;
+                    }
+                });
+            }
+        };
     }
 }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -11,7 +11,10 @@ import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.*;
+import com.tterrag.registrate.util.nullness.NonNullBiFunction;
+import com.tterrag.registrate.util.nullness.NonNullConsumer;
+import com.tterrag.registrate.util.nullness.NonNullFunction;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.Util;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
@@ -553,7 +556,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         // TODO improve this?
         if (block.isPresent()) {
             properties.descriptionId(block.get().getDescriptionId());
-            setData(ProviderType.LANG, NonNullBiConsumer.noop());
+            clearData(ProviderType.LANG);
         } else {
             properties.descriptionId(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
         }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -9,7 +9,10 @@ import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.*;
+import com.tterrag.registrate.util.nullness.NonNullBiFunction;
+import com.tterrag.registrate.util.nullness.NonNullConsumer;
+import com.tterrag.registrate.util.nullness.NonNullFunction;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
@@ -447,7 +450,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         // TODO improve this?
         if (block.isPresent()) {
             attributes.translationKey(block.get().getDescriptionId());
-            setData(ProviderType.LANG, NonNullBiConsumer.noop());
+            clearData(ProviderType.LANG);
         } else {
             attributes.translationKey(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
         }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -1,13 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.tterrag.registrate.AbstractRegistrate;
@@ -16,11 +8,7 @@ import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
-import com.tterrag.registrate.util.nullness.NonNullBiFunction;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import com.tterrag.registrate.util.nullness.*;
 
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
@@ -40,6 +28,13 @@ import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.registries.RegistryObject;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
 /**
  * A builder for fluids, allows for customization of the {@link ForgeFlowingFluid.Properties} and {@link FluidAttributes}, and creation of the source variant, fluid block, and bucket item, as well as
  * data associated with fluids (tags, etc.).
@@ -49,7 +44,7 @@ import net.minecraftforge.registries.RegistryObject;
  * @param <P>
  *            Parent object type
  */
-public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilder<Fluid, T, P, FluidBuilder<T, P>> {
+public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> extends AbstractBuilder<O, Fluid, T, P, FluidBuilder<O, T, P>> {
     
     private static class Builder extends FluidAttributes.Builder {
         
@@ -78,7 +73,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null);
     }
     
@@ -104,7 +99,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, ForgeFlowingFluid.Flowing::new);
     }
@@ -133,7 +128,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
     }
@@ -172,9 +167,9 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
+        FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket()
                 .tag(FluidTags.WATER);
 
@@ -196,7 +191,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
     private NonNullSupplier<? extends ForgeFlowingFluid> source;
     private List<TagKey<Fluid>> tags = new ArrayList<>();
 
-    protected FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    protected FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         super(owner, parent, "flowing_" + name, callback, Registry.FLUID_REGISTRY);
         this.stillTexture = stillTexture;
@@ -218,7 +213,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
+    public FluidBuilder<O, T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
         attributesCallback = attributesCallback.andThen(cons);
         return this;
     }
@@ -231,7 +226,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the properties
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> properties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
+    public FluidBuilder<O, T, P> properties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
         properties = properties.andThen(cons);
         return this;
     }
@@ -242,7 +237,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> defaultLang() {
+    public FluidBuilder<O, T, P> defaultLang() {
         return lang(f -> f.getAttributes().getTranslationKey(), RegistrateLangProvider.toEnglishName(sourceName));
     }
 
@@ -253,7 +248,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A localized English name
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> lang(String name) {
+    public FluidBuilder<O, T, P> lang(String name) {
         return lang(f -> f.getAttributes().getTranslationKey(), name);
     }
 
@@ -265,7 +260,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #source(NonNullFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultSource() {
+    public FluidBuilder<O, T, P> defaultSource() {
         if (this.defaultSource != null) {
             throw new IllegalStateException("Cannot set a default source after a custom source has been created");
         }
@@ -280,7 +275,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the fluid, which accepts the properties and returns a new fluid
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> source(NonNullFunction<ForgeFlowingFluid.Properties, ? extends ForgeFlowingFluid> factory) {
+    public FluidBuilder<O, T, P> source(NonNullFunction<ForgeFlowingFluid.Properties, ? extends ForgeFlowingFluid> factory) {
         this.defaultSource = false;
         this.source = NonNullSupplier.lazy(() -> factory.apply(makeProperties()));
         return this;
@@ -294,7 +289,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #block()} or {@link #block(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBlock() {
+    public FluidBuilder<O, T, P> defaultBlock() {
         if (this.defaultBlock != null) {
             throw new IllegalStateException("Cannot set a default block after a custom block has been created");
         }
@@ -307,7 +302,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public BlockBuilder<LiquidBlock, FluidBuilder<T, P>> block() {
+    public BlockBuilder<O, LiquidBlock, FluidBuilder<O, T, P>> block() {
         return block(LiquidBlock::new);
     }
 
@@ -320,13 +315,13 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the block, which accepts the block object and properties and returns a new block
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public <B extends LiquidBlock> BlockBuilder<B, FluidBuilder<T, P>> block(NonNullBiFunction<NonNullSupplier<? extends T>, BlockBehaviour.Properties, ? extends B> factory) {
+    public <B extends LiquidBlock> BlockBuilder<O, B, FluidBuilder<O, T, P>> block(NonNullBiFunction<NonNullSupplier<? extends T>, BlockBehaviour.Properties, ? extends B> factory) {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
         this.defaultBlock = false;
         NonNullSupplier<T> supplier = asSupplier();
-        return getOwner().<B, FluidBuilder<T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
+        return getOwner().<B, FluidBuilder<O, T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
                 .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noLootTable())
                 .properties(p -> {
                     // TODO is this ok?
@@ -338,7 +333,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
     }
 
     @Beta
-    public FluidBuilder<T, P> noBlock() {
+    public FluidBuilder<O, T, P> noBlock() {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
@@ -354,7 +349,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #bucket()} or {@link #bucket(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBucket() {
+    public FluidBuilder<O, T, P> defaultBucket() {
         if (this.defaultBucket != null) {
             throw new IllegalStateException("Cannot set a default bucket after a custom bucket has been created");
         }
@@ -367,7 +362,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public ItemBuilder<BucketItem, FluidBuilder<T, P>> bucket() {
+    public ItemBuilder<O, BucketItem, FluidBuilder<O, T, P>> bucket() {
         return bucket(BucketItem::new);
     }
 
@@ -380,7 +375,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the bucket item, which accepts the fluid object supplier and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <I extends BucketItem> ItemBuilder<I, FluidBuilder<T, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
+    public <I extends BucketItem> ItemBuilder<O, I, FluidBuilder<O, T, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -389,13 +384,13 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
         if (source == null) {
             throw new IllegalStateException("Cannot create a bucket before creating a source block");
         }
-        return getOwner().<I, FluidBuilder<T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
+        return getOwner().<I, FluidBuilder<O, T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
                 .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
                 .model((ctx, prov) -> prov.generated(ctx::getEntry, new ResourceLocation(getOwner().getModid(), "item/" + bucketName)));
     }
 
     @Beta
-    public FluidBuilder<T, P> noBucket() {
+    public FluidBuilder<O, T, P> noBucket() {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -411,8 +406,8 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> tag(TagKey<Fluid>... tags) {
-        FluidBuilder<T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
+    public final FluidBuilder<O, T, P> tag(TagKey<Fluid>... tags) {
+        FluidBuilder<O, T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
             ret.getOwner().<RegistrateTagsProvider<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
                     prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
@@ -429,7 +424,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> removeTag(TagKey<Fluid>... tags) {
+    public final FluidBuilder<O, T, P> removeTag(TagKey<Fluid>... tags) {
         this.tags.removeAll(Arrays.asList(tags));
         return this.removeTag(ProviderType.FLUID_TAGS, tags);
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -3,6 +3,7 @@ package com.tterrag.registrate.builders;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.FluidFactory;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
@@ -71,7 +72,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null);
@@ -97,11 +98,11 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param attributesFactory
      *            A factory that creates the fluid attributes instance
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, ForgeFlowingFluid.Flowing::new);
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, FluidFactory.FLOWING);
     }
     
     /**
@@ -126,10 +127,10 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param factory
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
     }
     
@@ -168,7 +169,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket()
                 .tag(FluidTags.WATER);
@@ -180,7 +181,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
     private final String sourceName;
     private final String bucketName;
     private final NonNullSupplier<FluidAttributes.Builder> attributes;
-    private final NonNullFunction<ForgeFlowingFluid.Properties, T> factory;
+    private final FluidFactory<T> factory;
 
     @Nullable
     private Boolean defaultSource, defaultBlock, defaultBucket;
@@ -192,7 +193,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
     private List<TagKey<Fluid>> tags = new ArrayList<>();
 
     protected FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         super(owner, parent, "flowing_" + name, callback, Registry.FLUID_REGISTRY);
         this.stillTexture = stillTexture;
         this.sourceName = name;
@@ -458,7 +459,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     @Override
     protected T createEntry() {
-        return factory.apply(makeProperties());
+        return factory.create(makeProperties());
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -13,8 +13,11 @@ import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.core.Registry;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.fml.DistExecutor;
@@ -246,4 +249,91 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     public ItemEntry<T> register() {
         return (ItemEntry<T>) super.register();
     }
+
+    /*
+        The following methods exist as shortcuts into Item Properties
+            Stops you needing to have long chains inside `properties()`
+            or having multiple `properties()` calls
+
+            ```
+            builder.properties(props -> props
+                .stacksTo(1)
+                .tab(CreativeModeTab.TAB_MISC)
+            )
+            ```
+
+            becomes
+
+            ```
+            builder.stacksTo(1).tab(CreativeModeTab.TAB_MISC)
+            ```
+     */
+    // region: Item Properties Wrappers
+    public final ItemBuilder<O, T, P> food(FoodProperties food)
+    {
+        return properties(properties -> properties.food(food));
+    }
+
+    public final ItemBuilder<O, T, P> stacksTo(int maxStackSize)
+    {
+        return properties(properties -> properties.stacksTo(maxStackSize));
+    }
+
+    public final ItemBuilder<O, T, P> defaultDurability(int durability)
+    {
+        return properties(properties -> properties.defaultDurability(durability));
+    }
+
+    public final ItemBuilder<O, T, P> durability(int durability)
+    {
+        return properties(properties -> properties.durability(durability));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla item reasons, should never be used with custom modded items. Modded should use {@link #craftRemainder(Supplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> craftRemainder(Item item)
+    {
+        return properties(properties -> properties.craftRemainder(item));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla item reasons, should never be used with custom modded items. Modded should use {@link #craftRemainder(Supplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> craftRemainder(ItemLike item)
+    {
+        return properties(properties -> properties.craftRemainder(item.asItem()));
+    }
+
+    public final ItemBuilder<O, T, P> craftRemainder(Supplier<? extends ItemLike> item)
+    {
+        return properties(properties -> properties.craftRemainder(item.get().asItem()));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla creative mode tab reasons, should never be used with custom modded creative mode tabs. Modded should use {@link #tab(NonNullSupplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> tab(CreativeModeTab tab)
+    {
+        return properties(properties -> properties.tab(tab));
+    }
+
+    public final ItemBuilder<O, T, P> rarity(Rarity rarity)
+    {
+        return properties(properties -> properties.rarity(rarity));
+    }
+
+    public final ItemBuilder<O, T, P> fireResistant()
+    {
+        return properties(Item.Properties::fireResistant);
+    }
+
+    public final ItemBuilder<O, T, P> setNoRepair()
+    {
+        return properties(Item.Properties::setNoRepair);
+    }
+    // endregion
 }

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.ItemFactory;
 import com.tterrag.registrate.providers.*;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.ItemEntry;
@@ -61,7 +62,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
      *            Factory to create the item
      * @return A new {@link ItemBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory) {
         return create(owner, parent, name, callback, factory, null);
     }
     
@@ -93,13 +94,13 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
      *            The {@link CreativeModeTab} for the object, can be null for none
      * @return A new {@link ItemBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory, @Nullable NonNullSupplier<? extends CreativeModeTab> tab) {
+    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory, @Nullable NonNullSupplier<? extends CreativeModeTab> tab) {
         return new ItemBuilder<>(owner, parent, name, callback, factory)
                 .defaultModel().defaultLang()
                 .transform(ib -> tab == null ? ib : ib.tab(tab));
     }
 
-    private final NonNullFunction<Item.Properties, T> factory;
+    private final ItemFactory<T> factory;
     
     private NonNullSupplier<Item.Properties> initialProperties = Item.Properties::new;
     private NonNullFunction<Item.Properties, Item.Properties> propertiesCallback = NonNullUnaryOperator.identity();
@@ -107,7 +108,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     @Nullable
     private NonNullSupplier<Supplier<ItemColor>> colorHandler;
     
-    protected ItemBuilder(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory) {
+    protected ItemBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory) {
         super(owner, parent, name, callback, Registry.ITEM_REGISTRY);
         this.factory = factory;
     }
@@ -237,7 +238,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     protected T createEntry() {
         Item.Properties properties = this.initialProperties.get();
         properties = propertiesCallback.apply(properties);
-        return factory.apply(properties);
+        return factory.create(properties);
     }
     
     @Override

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -12,7 +12,6 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 
 import net.minecraft.client.color.item.ItemColor;
-import net.minecraft.core.Registry;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.CreativeModeTab;
@@ -20,8 +19,9 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 import javax.annotation.Nullable;
@@ -109,7 +109,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     private NonNullSupplier<Supplier<ItemColor>> colorHandler;
     
     protected ItemBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory) {
-        super(owner, parent, name, callback, Registry.ITEM_REGISTRY);
+        super(owner, parent, name, callback, ForgeRegistries.Keys.ITEMS);
         this.factory = factory;
     }
 
@@ -160,10 +160,10 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     }
     
     protected void registerItemColor() {
-        OneTimeEventReceiver.addModListener(ColorHandlerEvent.Item.class, e -> {
+        OneTimeEventReceiver.addModListener(RegisterColorHandlersEvent.Item.class, e -> {
             NonNullSupplier<Supplier<ItemColor>> colorHandler = this.colorHandler;
             if (colorHandler != null) {
-                e.getItemColors().register(colorHandler.get().get(), getEntry());
+                e.register(colorHandler.get().get(), getEntry());
             }
         });
     }

--- a/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
@@ -11,12 +11,12 @@ import com.tterrag.registrate.util.nullness.NonnullType;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
-import net.minecraft.core.Registry;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 public class MenuBuilder<O extends AbstractRegistrate<O>, T extends AbstractContainerMenu, S extends Screen & MenuAccess<T>,  P> extends AbstractBuilder<O, MenuType<?>, MenuType<T>, P, MenuBuilder<O, T, S, P>> {
@@ -29,7 +29,7 @@ public class MenuBuilder<O extends AbstractRegistrate<O>, T extends AbstractCont
     }
 
     public MenuBuilder(O owner, P parent, String name, BuilderCallback<O> callback, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, S>> screenFactory) {
-        super(owner, parent, name, callback, Registry.MENU_REGISTRY);
+        super(owner, parent, name, callback, ForgeRegistries.Keys.MENU_TYPES);
         this.factory = factory;
         this.screenFactory = screenFactory;
     }

--- a/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.entry.MenuEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -22,7 +20,9 @@ import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.registries.RegistryObject;
 
-public class MenuBuilder<T extends AbstractContainerMenu, S extends Screen & MenuAccess<T>,  P> extends AbstractBuilder<MenuType<?>, MenuType<T>, P, MenuBuilder<T, S, P>> {
+import javax.annotation.Nullable;
+
+public class MenuBuilder<O extends AbstractRegistrate<O>, T extends AbstractContainerMenu, S extends Screen & MenuAccess<T>,  P> extends AbstractBuilder<O, MenuType<?>, MenuType<T>, P, MenuBuilder<O, T, S, P>> {
     
     public interface MenuFactory<T extends AbstractContainerMenu> {
         
@@ -42,11 +42,11 @@ public class MenuBuilder<T extends AbstractContainerMenu, S extends Screen & Men
     private final ForgeMenuFactory<T> factory;
     private final NonNullSupplier<ScreenFactory<T, S>> screenFactory;
 
-    public MenuBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
+    public MenuBuilder(O owner, P parent, String name, BuilderCallback<O> callback, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
         this(owner, parent, name, callback, (type, windowId, inv, $) -> factory.create(type, windowId, inv), screenFactory);
     }
 
-    public MenuBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
+    public MenuBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
         super(owner, parent, name, callback, Registry.MENU_REGISTRY);
         this.factory = factory;
         this.screenFactory = screenFactory;

--- a/src/main/java/com/tterrag/registrate/builders/NoConfigBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/NoConfigBuilder.java
@@ -7,11 +7,11 @@ import com.tterrag.registrate.util.nullness.NonnullType;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 
-public class NoConfigBuilder<R, T extends R, P> extends AbstractBuilder<R, T, P, NoConfigBuilder<R, T, P>> {
+public class NoConfigBuilder<O extends AbstractRegistrate<O>, R, T extends R, P> extends AbstractBuilder<O, R, T, P, NoConfigBuilder<O, R, T, P>> {
     
     private final NonNullSupplier<T> factory;
 
-    public NoConfigBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceKey<Registry<R>> registryType, NonNullSupplier<T> factory) {
+    public NoConfigBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceKey<Registry<R>> registryType, NonNullSupplier<T> factory) {
         super(owner, parent, name, callback, registryType);
         this.factory = factory;
     }

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockEntityFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockEntityFactory.java
@@ -1,0 +1,16 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockEntityFactory<@NonnullType BLOCK_ENTITY extends BlockEntity>
+{
+	@Nonnull BLOCK_ENTITY create(@Nonnull BlockEntityType<BLOCK_ENTITY> blockEntityType, @Nonnull BlockPos pos, @Nonnull BlockState blockState);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockFactory.java
@@ -1,0 +1,16 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockFactory<@NonnullType BLOCK extends Block>
+{
+	BlockFactory<Block> BLOCK = Block::new;
+
+	@Nonnull BLOCK create(@Nonnull BlockBehaviour.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockItemFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockItemFactory.java
@@ -1,0 +1,20 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockItemFactory<@NonnullType BLOCK extends Block, @NonnullType ITEM extends Item>
+{
+	@Nonnull ITEM create(@Nonnull BLOCK block, @Nonnull Item.Properties properties);
+
+	static <BLOCK extends Block> BlockItemFactory<BLOCK, BlockItem> blockItem()
+	{
+		return BlockItem::new;
+	}
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/EnchantmentFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/EnchantmentFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface EnchantmentFactory<@NonnullType ENCHANTMENT extends Enchantment>
+{
+	@Nonnull ENCHANTMENT create(@Nonnull Enchantment.Rarity rarity, @Nonnull EnchantmentCategory category, @Nonnull EquipmentSlot... slots);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/EntityTypeFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/EntityTypeFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface EntityTypeFactory<@NonnullType ENTITY extends Entity> extends EntityType.EntityFactory<ENTITY>
+{
+	@Override @Nonnull ENTITY create(@Nonnull EntityType<ENTITY> entityType, @Nonnull Level level);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/FluidFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/FluidFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface FluidFactory<@NonnullType FLUID extends ForgeFlowingFluid>
+{
+	FluidFactory<ForgeFlowingFluid.Flowing> FLOWING = ForgeFlowingFluid.Flowing::new;
+
+	@Nonnull FLUID create(@Nonnull ForgeFlowingFluid.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/FluidTypeFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/FluidTypeFactory.java
@@ -1,0 +1,12 @@
+package com.tterrag.registrate.builders.factory;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fluids.FluidType;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface FluidTypeFactory
+{
+	@Nonnull FluidType create(@Nonnull FluidType.Properties properties, @Nonnull ResourceLocation stillTexture, @Nonnull ResourceLocation flowingTexture);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/ItemFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/ItemFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.item.Item;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface ItemFactory<@NonnullType ITEM extends Item>
+{
+	ItemFactory<Item> ITEM = Item::new;
+
+	@Nonnull ITEM create(@Nonnull Item.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/MenuFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/MenuFactory.java
@@ -1,0 +1,29 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface MenuFactory<@NonnullType MENU extends AbstractContainerMenu>
+{
+	MENU create(@Nullable MenuType<? extends MENU> menuType, int windowId, @Nonnull Inventory playerInventory);
+
+	static <@NonnullType MENU extends AbstractContainerMenu> MenuFactory.WithBuffer<MENU> withIgnoredBuffer(MenuFactory<MENU> menuFactory)
+	{
+		return (menuType, windowId, playerInventory, buffer) -> menuFactory.create(menuType, windowId, playerInventory);
+	}
+
+	@FunctionalInterface
+	interface WithBuffer<@NonnullType MENU extends AbstractContainerMenu>
+	{
+		MENU create(@Nullable MenuType<? extends MENU> menuType, int windowId, @NotNull Inventory playerInventory, @Nonnull FriendlyByteBuf buffer);
+	}
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/MenuScreenFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/MenuScreenFactory.java
@@ -1,0 +1,17 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.MenuAccess;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface MenuScreenFactory<@NonnullType MENU extends AbstractContainerMenu, @NonnullType SCREEN extends Screen & MenuAccess<MENU>>
+{
+	@Nonnull SCREEN create(@Nonnull MENU menu, @Nonnull Inventory playerInventory, @Nonnull Component titleComponent);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/package-info.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/package-info.java
@@ -1,0 +1,4 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@net.minecraft.MethodsReturnNonnullByDefault
+@com.tterrag.registrate.util.nullness.FieldsAreNonnullByDefault
+package com.tterrag.registrate.builders.factory;

--- a/src/main/java/com/tterrag/registrate/providers/DataGenContext.java
+++ b/src/main/java/com/tterrag/registrate/providers/DataGenContext.java
@@ -1,13 +1,14 @@
 package com.tterrag.registrate.providers;
 
+import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.builders.Builder;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Delegate;
+
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -34,7 +35,7 @@ public class DataGenContext<R, E extends R> implements NonNullSupplier<E> {
         return entry.get();
     }
 
-    public static <R, E extends R> DataGenContext<R, E> from(Builder<R, E, ?, ?> builder, ResourceKey<? extends Registry<R>> type) {
+    public static <O extends AbstractRegistrate<O>, R, E extends R> DataGenContext<R, E> from(Builder<O, R, E, ?, ?> builder, ResourceKey<? extends Registry<R>> type) {
         return new DataGenContext<R, E>(NonNullSupplier.of(builder.getOwner().<R, E>get(builder.getName(), type)), builder.getName(),
                 new ResourceLocation(builder.getOwner().getModid(), builder.getName()));
     }

--- a/src/main/java/com/tterrag/registrate/providers/ProviderType.java
+++ b/src/main/java/com/tterrag/registrate/providers/ProviderType.java
@@ -1,10 +1,5 @@
 package com.tterrag.registrate.providers;
 
-import java.util.Map;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.loot.RegistrateLootTableProvider;
 import com.tterrag.registrate.util.nullness.FieldsAreNonnullByDefault;
@@ -13,10 +8,25 @@ import com.tterrag.registrate.util.nullness.NonNullFunction;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 
 import net.minecraft.core.Registry;
+import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.entity.animal.CatVariant;
+import net.minecraft.world.entity.decoration.PaintingVariant;
+import net.minecraft.world.item.Instrument;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BannerPattern;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorPreset;
+import net.minecraft.world.level.levelgen.presets.WorldPreset;
+import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Map;
 
 /**
  * Represents a type of data that can be generated, and specifies a factory for the provider.
@@ -43,6 +53,16 @@ public interface ProviderType<T extends RegistrateProvider> {
     public static final ProviderType<RegistrateTagsProvider<Fluid>> FLUID_TAGS = register("tags/fluid", type -> (p, e) -> new RegistrateTagsProvider<Fluid>(p, type, "fluids", e.getGenerator(), Registry.FLUID, e.getExistingFileHelper()));
     public static final ProviderType<RegistrateTagsProvider<EntityType<?>>> ENTITY_TAGS = register("tags/entity", type -> (p, e) -> new RegistrateTagsProvider<EntityType<?>>(p, type, "entity_types", e.getGenerator(), Registry.ENTITY_TYPE, e.getExistingFileHelper()));
 
+    ProviderType<RegistrateTagsProvider<BannerPattern>> BANNER_PATTERN_TAGS = register("tags/banner_pattern", type -> (p, e) -> new RegistrateTagsProvider<BannerPattern>(p, type, "banner_pattern", e.getGenerator(), Registry.BANNER_PATTERN, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<Biome>> BIOME_TAGS = register("tags/worldgen/biome", type -> (p, e) -> new RegistrateTagsProvider<Biome>(p, type, "worldgen/biome", e.getGenerator(), BuiltinRegistries.BIOME, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<CatVariant>> CAT_VARIANT_TAGS = register("tags/cat_variant", type -> (p, e) -> new RegistrateTagsProvider<CatVariant>(p, type, "cat_variant", e.getGenerator(), Registry.CAT_VARIANT, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<FlatLevelGeneratorPreset>> FLAT_LEVEL_GENERATOR_PRESET_TAGS = register("tags/worldgen/flat_level_generator_preset", type -> (p, e) -> new RegistrateTagsProvider<FlatLevelGeneratorPreset>(p, type, "worldgen/flat_level_generator_preset", e.getGenerator(), BuiltinRegistries.FLAT_LEVEL_GENERATOR_PRESET, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<GameEvent>> GAME_EVENT_TAGS = register("tags/game_events", type -> (p, e) -> new RegistrateTagsProvider<GameEvent>(p, type, "game_events", e.getGenerator(), Registry.GAME_EVENT, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<Instrument>> INSTRUMENT_TAGS = register("tags/instrument", type -> (p, e) -> new RegistrateTagsProvider<Instrument>(p, type, "instrument", e.getGenerator(), Registry.INSTRUMENT, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<PaintingVariant>> PAINTING_VARIANT_TAGS = register("tags/painting_variant", type -> (p, e) -> new RegistrateTagsProvider<PaintingVariant>(p, type, "painting_variant", e.getGenerator(), Registry.PAINTING_VARIANT, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<PoiType>> POI_TYPE_TAGS = register("tags/point_of_interest_type", type -> (p, e) -> new RegistrateTagsProvider<PoiType>(p, type, "point_of_interest_type", e.getGenerator(), Registry.POINT_OF_INTEREST_TYPE, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<Structure>> STRUCTURE_TAGS = register("tags/worldgen/structure", type -> (p, e) -> new RegistrateTagsProvider<Structure>(p, type, "worldgen/structure", e.getGenerator(), BuiltinRegistries.STRUCTURES, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<WorldPreset>> WORLD_PRESET_TAGS = register("tags/worldgen/world_preset", type -> (p, e) -> new RegistrateTagsProvider<WorldPreset>(p, type, "worldgen/world_preset", e.getGenerator(), BuiltinRegistries.WORLD_PRESET, e.getExistingFileHelper()));
     // CLIENT DATA
     public static final ProviderType<RegistrateBlockstateProvider> BLOCKSTATE = register("blockstate", (p, e) -> new RegistrateBlockstateProvider(p, e.getGenerator(), e.getExistingFileHelper()));
     public static final ProviderType<RegistrateItemModelProvider> ITEM_MODEL = register("item_model", (p, e, existing) -> new RegistrateItemModelProvider(p, e.getGenerator(), ((RegistrateBlockstateProvider)existing.get(BLOCKSTATE)).getExistingFileHelper()));

--- a/src/main/java/com/tterrag/registrate/providers/ProviderType.java
+++ b/src/main/java/com/tterrag/registrate/providers/ProviderType.java
@@ -22,7 +22,7 @@ import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorPreset;
 import net.minecraft.world.level.levelgen.presets.WorldPreset;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.material.Fluid;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
+import net.minecraftforge.data.event.GatherDataEvent;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateDataProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateDataProvider.java
@@ -1,26 +1,21 @@
 package com.tterrag.registrate.providers;
 
-import java.io.IOException;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.DebugMarkers;
 import com.tterrag.registrate.util.nullness.NonnullType;
-
 import lombok.extern.log4j.Log4j2;
+
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
+import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Log4j2
 public class RegistrateDataProvider implements DataProvider {

--- a/src/main/java/com/tterrag/registrate/util/entry/EntityEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/EntityEntry.java
@@ -1,13 +1,13 @@
 package com.tterrag.registrate.util.entry;
 
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.registries.RegistryObject;
+
+import javax.annotation.Nullable;
 
 public class EntityEntry<T extends Entity> extends RegistryEntry<EntityType<T>> {
 

--- a/src/main/java/com/tterrag/registrate/util/entry/FluidEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/FluidEntry.java
@@ -1,17 +1,17 @@
 package com.tterrag.registrate.util.entry;
 
-import java.util.Optional;
-
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 public class FluidEntry<T extends ForgeFlowingFluid> extends RegistryEntry<T> {
 
@@ -32,17 +32,21 @@ public class FluidEntry<T extends ForgeFlowingFluid> extends RegistryEntry<T> {
     }
 
     @SuppressWarnings("unchecked")
-    <S extends ForgeFlowingFluid> S getSource() {
+    public <S extends ForgeFlowingFluid> S getSource() {
         return (S) get().getSource();
     }
 
+    public FluidType getType() {
+        return get().getFluidType();
+    }
+
     @SuppressWarnings({ "unchecked", "null" })
-    <B extends Block> Optional<B> getBlock() {
+    public <B extends Block> Optional<B> getBlock() {
         return (Optional<B>) Optional.ofNullable(block).map(RegistryEntry::get);
     }
 
     @SuppressWarnings({ "unchecked", "null" })
-    <I extends Item> Optional<I> getBucket() {
+    public <I extends Item> Optional<I> getBucket() {
         return Optional.ofNullable((I) get().getBucket());
     }
 }

--- a/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
@@ -7,18 +7,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.registries.RegistryObject;
 
-public class ItemProviderEntry<T extends ItemLike> extends RegistryEntry<T> {
+public class ItemProviderEntry<T extends ItemLike> extends RegistryEntry<T> implements ItemLike {
 
     public ItemProviderEntry(AbstractRegistrate<?> owner, RegistryObject<T> delegate) {
         super(owner, delegate);
     }
 
     public ItemStack asStack() {
-        return new ItemStack(get());
+        return new ItemStack(this);
     }
 
     public ItemStack asStack(int count) {
-        return new ItemStack(get(), count);
+        return new ItemStack(this, count);
     }
 
     public boolean isIn(ItemStack stack) {
@@ -27,5 +27,11 @@ public class ItemProviderEntry<T extends ItemLike> extends RegistryEntry<T> {
 
     public boolean is(Item item) {
         return get().asItem() == item;
+    }
+
+    @Override
+    public Item asItem()
+    {
+        return get().asItem();
     }
 }

--- a/src/main/java/com/tterrag/registrate/util/entry/MenuEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/MenuEntry.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.util.entry;
 
-import java.util.function.Consumer;
-
 import com.tterrag.registrate.AbstractRegistrate;
 
 import net.minecraft.network.FriendlyByteBuf;
@@ -14,6 +12,8 @@ import net.minecraft.world.inventory.MenuConstructor;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.network.NetworkHooks;
 import net.minecraftforge.registries.RegistryObject;
+
+import java.util.function.Consumer;
 
 public class MenuEntry<T extends AbstractContainerMenu> extends RegistryEntry<MenuType<T>> {
 
@@ -38,10 +38,10 @@ public class MenuEntry<T extends AbstractContainerMenu> extends RegistryEntry<Me
     }
 
     public void open(ServerPlayer player, Component displayName, MenuConstructor provider) {
-        NetworkHooks.openGui(player, new SimpleMenuProvider(provider, displayName));
+        NetworkHooks.openScreen(player, new SimpleMenuProvider(provider, displayName));
     }
 
     public void open(ServerPlayer player, Component displayName, MenuConstructor provider, Consumer<FriendlyByteBuf> extraData) {
-        NetworkHooks.openGui(player, new SimpleMenuProvider(provider, displayName), extraData);
+        NetworkHooks.openScreen(player, new SimpleMenuProvider(provider, displayName), extraData);
     }
 }

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -1,21 +1,11 @@
 package com.tterrag.registrate.test.mod;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.tterrag.registrate.Registrate;
 import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.util.DataIngredient;
-import com.tterrag.registrate.util.entry.BlockEntityEntry;
-import com.tterrag.registrate.util.entry.BlockEntry;
-import com.tterrag.registrate.util.entry.EntityEntry;
-import com.tterrag.registrate.util.entry.FluidEntry;
-import com.tterrag.registrate.util.entry.ItemEntry;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.tterrag.registrate.util.entry.*;
 import com.tterrag.registrate.util.nullness.NonnullType;
 
 import net.minecraft.advancements.Advancement;
@@ -54,11 +44,7 @@ import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantment.Rarity;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
@@ -88,8 +74,10 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryBuilder;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Mod("testmod")
 public class TestMod {
@@ -322,7 +310,7 @@ public class TestMod {
 //            .addSpawn(EntityClassification.CREATURE, () -> EntityType.IRON_GOLEM, 1, 2, 3)
 //            .addSpawn(EntityClassification.CREATURE, testentity, 1, 4, 8)
 //            .register();
-//    
+//
 //    private final RegistryEntry<TestBiome> testbiome2 = registrate.object("testbiome2")
 //            .biome(TestBiome::new)
 //            .properties(b -> b.category(Category.DESERT)
@@ -341,7 +329,7 @@ public class TestMod {
 //            .copyCarvers(() -> Biomes.DESERT)
 //            .copySpawns(() -> Biomes.DESERT)
 //            .register();
-//    
+//
 //    private @Nullable DimensionType testdimensiontype;
 //    private final RegistryEntry<ModDimension> testdimension = registrate.object("testdimension")
 //            .dimension(OverworldDimension::new)
@@ -354,11 +342,11 @@ public class TestMod {
     private final RegistryEntry<TestCustomRegistryEntry> testcustom = registrate.object("testcustom")
             .simple(CUSTOM_REGISTRY, TestCustomRegistryEntry::new);
 
-//    private final BlockBuilder<Block, Registrate> INVALID_TEST = registrate.object("invalid")
+//    private final BlockBuilder<Registrate, Block, Registrate> INVALID_TEST = registrate.object("invalid")
 //            .block(Block::new)
 //            .addLayer(() -> RenderType::getTranslucent);
     
-    private static <T extends Block, P> @NonnullType BlockBuilder<T, P> applyDiamondDrop(BlockBuilder<T, P> builder) {
+    private static <T extends Block, P> @NonnullType BlockBuilder<Registrate, T, P> applyDiamondDrop(BlockBuilder<Registrate, T, P> builder) {
         return builder.loot((prov, block) -> prov.dropOther(block, Items.DIAMOND));
     }
 


### PR DESCRIPTION
This PR brings various quality of life changes to Registrate which I used to make use of in a seperate child of mod Registrate called Registrator, This just merges the 2 into Registrate.

These changes consit of the following
- All builders now have a generic reference to their AbstractRegistrate owner, this means builders know exactly what registrate type owns them.
    - Useful only for custom registrate types that have new methods, this change allows calling those methods without needing to cast the builders owner property.
- Provider types for the new & missing vanilla tag types
- Implements ItemLike onto ItemProviderEntry so that it can be passed into places that expect an ItemLike object
    - ItemStack constructor is good example for this use case
- Added functional factory interfaces for each builder type
    - This change is not so necessary, but makes reading code and lambdas easier to eye, imo
- Shortcut methods inside of various builder to their property builder classes
    - ItemBuilder, BlockBuilder, EntityTypeBuilder
    - These methods remove the need to chain calls inside of .properties() or call .properties() multiple times
- Easy method to quickly clear a data provider callback for a given builder