### PR TITLE
[1.18] Various quality of life changes

### DIFF
--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -1,68 +1,30 @@
 package com.tterrag.registrate;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.message.Message;
-
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Table;
-import com.tterrag.registrate.builders.BlockBuilder;
-import com.tterrag.registrate.builders.BlockEntityBuilder;
+import com.google.common.collect.*;
+import com.tterrag.registrate.builders.*;
 import com.tterrag.registrate.builders.BlockEntityBuilder.BlockEntityFactory;
-import com.tterrag.registrate.builders.Builder;
-import com.tterrag.registrate.builders.BuilderCallback;
-import com.tterrag.registrate.builders.EnchantmentBuilder;
 import com.tterrag.registrate.builders.EnchantmentBuilder.EnchantmentFactory;
-import com.tterrag.registrate.builders.EntityBuilder;
-import com.tterrag.registrate.builders.FluidBuilder;
-import com.tterrag.registrate.builders.ItemBuilder;
-import com.tterrag.registrate.builders.MenuBuilder;
 import com.tterrag.registrate.builders.MenuBuilder.ForgeMenuFactory;
 import com.tterrag.registrate.builders.MenuBuilder.MenuFactory;
 import com.tterrag.registrate.builders.MenuBuilder.ScreenFactory;
-import com.tterrag.registrate.builders.NoConfigBuilder;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateDataProvider;
 import com.tterrag.registrate.providers.RegistrateProvider;
 import com.tterrag.registrate.util.DebugMarkers;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.NonNullBiFunction;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
-import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
-import com.tterrag.registrate.util.nullness.NonnullType;
-
+import com.tterrag.registrate.util.nullness.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.message.Message;
+
 import net.minecraft.Util;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
@@ -93,13 +55,17 @@ import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
-import net.minecraftforge.registries.IForgeRegistryEntry;
-import net.minecraftforge.registries.NewRegistryEvent;
-import net.minecraftforge.registries.RegistryBuilder;
-import net.minecraftforge.registries.RegistryManager;
-import net.minecraftforge.registries.RegistryObject;
+import net.minecraftforge.registries.*;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 /**
  * Manages all registrations and data generators for a mod.
@@ -554,7 +520,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
      *            A callback to be invoked during data generation
      * @return this {@link AbstractRegistrate}
      */
-    public <P extends RegistrateProvider, R extends IForgeRegistryEntry<R>> S setDataGenerator(Builder<R, ?, ?, ?> builder, ProviderType<P> type, NonNullConsumer<? extends P> cons) {
+    public <P extends RegistrateProvider, R extends IForgeRegistryEntry<R>> S setDataGenerator(Builder<S, R, ?, ?, ?> builder, ProviderType<P> type, NonNullConsumer<? extends P> cons) {
         return this.<P, R>setDataGenerator(builder.getName(), builder.getRegistryKey(), type, cons);
     }
 
@@ -856,7 +822,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
      *            The {@link Function function} to apply
      * @return the resultant {@link Builder}
      */
-    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<R, T, P, S2>> S2 transform(NonNullFunction<S, S2> func) {
+    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<S, R, T, P, S2>> S2 transform(NonNullFunction<S, S2> func) {
         return func.apply(self());
     }
     
@@ -877,7 +843,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
      *            The factory to create the builder
      * @return The {@link Builder} instance
      */
-    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<R, T, P, S2>> S2 entry(NonNullBiFunction<String, BuilderCallback, S2> factory) {
+    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<S, R, T, P, S2>> S2 entry(NonNullBiFunction<String, BuilderCallback<S>, S2> factory) {
         return entry(currentName(), callback -> factory.apply(currentName(), callback));
     }
 
@@ -898,16 +864,16 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
      *            The factory to create the builder
      * @return The {@link Builder} instance
      */
-    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<R, T, P, S2>> S2 entry(String name, NonNullFunction<BuilderCallback.NewBuilderCallback, S2> factory) {
+    public <R extends IForgeRegistryEntry<R>, T extends R, P, S2 extends Builder<S, R, T, P, S2>> S2 entry(String name, NonNullFunction<BuilderCallback.NewBuilderCallback<S>, S2> factory) {
         return factory.apply(this::accept);
     }
 
     @Deprecated
-    protected <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> creator, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
+    protected <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<S, R, T, ?, ?> builder, NonNullSupplier<? extends T> creator, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
         return accept(name, this.<R>getRegistryKeyByClass(type), builder, creator, entryFactory);
     }
 
-    protected <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> creator, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
+    protected <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<S, R, T, ?, ?> builder, NonNullSupplier<? extends T> creator, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
         Registration<R, T> reg = new Registration<>(new ResourceLocation(modid, name), type, creator, entryFactory);
         log.debug(DebugMarkers.REGISTER, "Captured registration for entry {} of type {}", name, type.location());
         registerCallbacks.removeAll(Pair.of(name, type)).forEach(callback -> {
@@ -946,7 +912,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
 
     public <R extends IForgeRegistryEntry<R>, T extends R, P> RegistryEntry<T> simple(P parent, String name, ResourceKey<? extends Registry<R>> registryType, NonNullSupplier<T> factory) {
-        return entry(name, callback -> new NoConfigBuilder<R, T, P>(this, parent, name, callback, registryType, factory)).register();
+        return entry(name, callback -> new NoConfigBuilder<S, R, T, P>(self(), parent, name, callback, registryType, factory)).register();
     }
 
     @Deprecated
@@ -967,242 +933,242 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     @SuppressWarnings("deprecation")
     @Deprecated
     public <R extends IForgeRegistryEntry<R>, T extends R, P> RegistryEntry<T> simple(P parent, String name, Class<? super R> registryType, NonNullSupplier<T> factory) {
-        return entry(name, callback -> new NoConfigBuilder<R, T, P>(this, parent, name, callback, registryType, factory)).register();
+        return entry(name, callback -> new NoConfigBuilder<S, R, T, P>(self(), parent, name, callback, registryType, factory)).register();
     }
 
     // Items
     
-    public <T extends Item> ItemBuilder<T, S> item(NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(NonNullFunction<Item.Properties, T> factory) {
         return item(self(), factory);
     }
     
-    public <T extends Item> ItemBuilder<T, S> item(String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(String name, NonNullFunction<Item.Properties, T> factory) {
         return item(self(), name, factory);
     }
     
-    public <T extends Item, P> ItemBuilder<T, P> item(P parent, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, NonNullFunction<Item.Properties, T> factory) {
         return item(parent, currentName(), factory);
     }
     
-    public <T extends Item, P> ItemBuilder<T, P> item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
         // TODO clean this up when NonNullLazyValue is fixed better
         Supplier<? extends @NonnullType CreativeModeTab> currentTab = this.currentTab;
-        return entry(name, callback -> ItemBuilder.create(this, parent, name, callback, factory, currentTab == null ? null : currentTab::get));
+        return entry(name, callback -> ItemBuilder.create(self(), parent, name, callback, factory, currentTab == null ? null : currentTab::get));
     }
     
     // Blocks
     
-    public <T extends Block> BlockBuilder<T, S> block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), factory);
     }
     
-    public <T extends Block> BlockBuilder<T, S> block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), name, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(parent, currentName(), factory);
     }
     
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(parent, name, Material.STONE, factory);
     }
     
-    public <T extends Block> BlockBuilder<T, S> block(Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), material, factory);
     }
     
-    public <T extends Block> BlockBuilder<T, S> block(String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), name, material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(parent, currentName(), material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
-        return entry(name, callback -> BlockBuilder.create(this, parent, name, callback, factory, material));
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+        return entry(name, callback -> BlockBuilder.create(self(), parent, name, callback, factory, material));
     }
     
     // Entities
     
-    public <T extends Entity> EntityBuilder<T, S> entity(EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), factory, classification);
     }
     
-    public <T extends Entity> EntityBuilder<T, S> entity(String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(String name, EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), name, factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<T, P> entity(P parent, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, EntityFactory<T> factory, MobCategory classification) {
         return entity(parent, currentName(), factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<T, P> entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
-        return entry(name, callback -> EntityBuilder.create(this, parent, name, callback, factory, classification));
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
+        return entry(name, callback -> EntityBuilder.create(self(), parent, name, callback, factory, classification));
     }
     
     // Block Entities
     
-    public <T extends BlockEntity> BlockEntityBuilder<T, S> blockEntity(BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity> BlockEntityBuilder<S, T, S> blockEntity(BlockEntityFactory<T> factory) {
         return blockEntity(self(), factory);
     }
     
-    public <T extends BlockEntity> BlockEntityBuilder<T, S> blockEntity(String name, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity> BlockEntityBuilder<S, T, S> blockEntity(String name, BlockEntityFactory<T> factory) {
         return blockEntity(self(), name, factory);
     }
     
-    public <T extends BlockEntity, P> BlockEntityBuilder<T, P> blockEntity(P parent, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, P> BlockEntityBuilder<S, T, P> blockEntity(P parent, BlockEntityFactory<T> factory) {
         return blockEntity(parent, currentName(), factory);
     }
     
-    public <T extends BlockEntity, P> BlockEntityBuilder<T, P> blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
-        return entry(name, callback -> BlockEntityBuilder.create(this, parent, name, callback, factory));
+    public <T extends BlockEntity, P> BlockEntityBuilder<S, T, P> blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
+        return entry(name, callback -> BlockEntityBuilder.create(self(), parent, name, callback, factory));
     }
     
     // Fluids
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid() {
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid() {
         return fluid(self());
     }
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), stillTexture, flowingTexture);
     }
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
         return fluid(self(), stillTexture, flowingTexture, attributesFactory);
     }
     
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(self(), stillTexture, flowingTexture, factory);
     }
     
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name) {
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name) {
         return fluid(self(), name);
     }
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
     
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public FluidBuilder<S, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, attributesFactory);
     }
     
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, factory);
     }
     
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
     }
         
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent) {
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent) {
         return fluid(parent, currentName());
     }
     
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
     
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory);
     }
     
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, factory);
     }
     
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name) {
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name) {
         return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"));
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture));
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture));
     }
     
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <P> FluidBuilder<S, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory));
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory));
     }
     
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, factory));
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, factory));
     }
     
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
+        return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
     }
     
     // Menu
     
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
-        return entry(name, callback -> new MenuBuilder<T, SC, P>(this, parent, name, callback, factory, screenFactory));
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+        return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<T, SC, S> menu(ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<T, SC, S> menu(String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<T, SC, P> menu(P parent, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<T, SC, P> menu(P parent, String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
-        return entry(name, callback -> new MenuBuilder<T, SC, P>(this, parent, name, callback, factory, screenFactory));
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+        return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
     
     // Enchantment
     
-    public <T extends Enchantment> EnchantmentBuilder<T, S> enchantment(EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    public <T extends Enchantment> EnchantmentBuilder<S, T, S> enchantment(EnchantmentCategory type, EnchantmentFactory<T> factory) {
         return enchantment(self(), type, factory);
     }
     
-    public <T extends Enchantment> EnchantmentBuilder<T, S> enchantment(String name, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    public <T extends Enchantment> EnchantmentBuilder<S, T, S> enchantment(String name, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         return enchantment(self(), name, type, factory);
     }
     
-    public <T extends Enchantment, P> EnchantmentBuilder<T, P> enchantment(P parent, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    public <T extends Enchantment, P> EnchantmentBuilder<S, T, P> enchantment(P parent, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         return enchantment(parent, currentName(), type, factory);
     }
     
-    public <T extends Enchantment, P> EnchantmentBuilder<T, P> enchantment(P parent, String name, EnchantmentCategory type, EnchantmentFactory<T> factory) {
-        return entry(name, callback -> EnchantmentBuilder.create(this, parent, name, callback, type, factory));
+    public <T extends Enchantment, P> EnchantmentBuilder<S, T, P> enchantment(P parent, String name, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+        return entry(name, callback -> EnchantmentBuilder.create(self(), parent, name, callback, type, factory));
     }
 }

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -5,11 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.*;
 import com.tterrag.registrate.builders.*;
-import com.tterrag.registrate.builders.BlockEntityBuilder.BlockEntityFactory;
-import com.tterrag.registrate.builders.EnchantmentBuilder.EnchantmentFactory;
-import com.tterrag.registrate.builders.MenuBuilder.ForgeMenuFactory;
-import com.tterrag.registrate.builders.MenuBuilder.MenuFactory;
-import com.tterrag.registrate.builders.MenuBuilder.ScreenFactory;
+import com.tterrag.registrate.builders.factory.*;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateDataProvider;
 import com.tterrag.registrate.providers.RegistrateProvider;
@@ -33,7 +29,6 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType.EntityFactory;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.CreativeModeTab;
@@ -42,7 +37,6 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.data.loading.DatagenModLoader;
@@ -73,7 +67,7 @@ import java.util.stream.Collectors;
  * Generally <em>not</em> thread-safe, as it holds the current name of the object being built statefully, and uses non-concurrent collections.
  * <p>
  * Begin a new object via {@link #object(String)}. This name will be used for all future entries until the next invocation of {@link #object(String)}. Alternatively, the methods that accept a name
- * parameter (such as {@link #block(String, NonNullFunction)}) can be used. These do not affect the current name state.
+ * parameter (such as {@link #block(String, BlockFactory)}) can be used. These do not affect the current name state.
  * <p>
  * A simple use may look like:
  * 
@@ -938,19 +932,19 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     // Items
     
-    public <T extends Item> ItemBuilder<S, T, S> item(NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(ItemFactory<T> factory) {
         return item(self(), factory);
     }
     
-    public <T extends Item> ItemBuilder<S, T, S> item(String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item> ItemBuilder<S, T, S> item(String name, ItemFactory<T> factory) {
         return item(self(), name, factory);
     }
     
-    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, ItemFactory<T> factory) {
         return item(parent, currentName(), factory);
     }
     
-    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P> ItemBuilder<S, T, P> item(P parent, String name, ItemFactory<T> factory) {
         // TODO clean this up when NonNullLazyValue is fixed better
         Supplier<? extends @NonnullType CreativeModeTab> currentTab = this.currentTab;
         return entry(name, callback -> ItemBuilder.create(self(), parent, name, callback, factory, currentTab == null ? null : currentTab::get));
@@ -958,53 +952,53 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     
     // Blocks
     
-    public <T extends Block> BlockBuilder<S, T, S> block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(BlockFactory<T> factory) {
         return block(self(), factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, BlockFactory<T> factory) {
         return block(self(), name, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, BlockFactory<T> factory) {
         return block(parent, currentName(), factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, BlockFactory<T> factory) {
         return block(parent, name, Material.STONE, factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(Material material, BlockFactory<T> factory) {
         return block(self(), material, factory);
     }
     
-    public <T extends Block> BlockBuilder<S, T, S> block(String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block> BlockBuilder<S, T, S> block(String name, Material material, BlockFactory<T> factory) {
         return block(self(), name, material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, Material material, BlockFactory<T> factory) {
         return block(parent, currentName(), material, factory);
     }
     
-    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, Material material, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P> BlockBuilder<S, T, P> block(P parent, String name, Material material, BlockFactory<T> factory) {
         return entry(name, callback -> BlockBuilder.create(self(), parent, name, callback, factory, material));
     }
     
     // Entities
     
-    public <T extends Entity> EntityBuilder<S, T, S> entity(EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(self(), factory, classification);
     }
     
-    public <T extends Entity> EntityBuilder<S, T, S> entity(String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity> EntityBuilder<S, T, S> entity(String name, EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(self(), name, factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, EntityTypeFactory<T> factory, MobCategory classification) {
         return entity(parent, currentName(), factory, classification);
     }
     
-    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P> EntityBuilder<S, T, P> entity(P parent, String name, EntityTypeFactory<T> factory, MobCategory classification) {
         return entry(name, callback -> EntityBuilder.create(self(), parent, name, callback, factory, classification));
     }
     
@@ -1042,12 +1036,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(self(), stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(self(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
@@ -1065,12 +1059,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid> FluidBuilder<S, T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(self(), name, stillTexture, flowingTexture, attributesFactory, factory);
     }
         
@@ -1088,12 +1082,12 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, factory);
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, attributesFactory, factory);
     }
     
@@ -1111,46 +1105,46 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, factory));
     }
     
     public <T extends ForgeFlowingFluid, P> FluidBuilder<S, T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         return entry(name, callback -> FluidBuilder.create(self(), parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory));
     }
     
     // Menu
     
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>> MenuBuilder<S, T, SC, S> menu(String name, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(self(), name, factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return menu(parent, currentName(), factory, screenFactory);
     }
 
-    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, SC>> screenFactory) {
+    public <T extends AbstractContainerMenu, SC extends Screen & MenuAccess<T>, P> MenuBuilder<S, T, SC, P> menu(P parent, String name, MenuFactory.WithBuffer<T> factory, NonNullSupplier<MenuScreenFactory<T, SC>> screenFactory) {
         return entry(name, callback -> new MenuBuilder<S, T, SC, P>(self(), parent, name, callback, factory, screenFactory));
     }
     

--- a/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/AbstractBuilder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.tterrag.registrate.AbstractRegistrate;
@@ -13,10 +11,10 @@ import com.tterrag.registrate.util.entry.RegistryEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiFunction;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
@@ -25,11 +23,15 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.Arrays;
+
 /**
  * Base class which most builders should extend, instead of implementing [@link {@link Builder} directly.
  * <p>
  * Provides the most basic functionality, and some utility methods that remove the need to pass the registry class.
  *
+ * @param <O>
+ *            The type of Registrate owning the builder & compiled object.
  * @param <R>
  *            Type of the registry for the current object. This is the concrete base class that all registry entries must extend, and the type used for the forge registry itself.
  * @param <T>
@@ -41,16 +43,16 @@ import net.minecraftforge.registries.RegistryObject;
  * @see Builder
  */
 @RequiredArgsConstructor
-public abstract class AbstractBuilder<R extends IForgeRegistryEntry<R>, T extends R, P, S extends AbstractBuilder<R, T, P, S>> implements Builder<R, T, P, S> {
+public abstract class AbstractBuilder<O extends AbstractRegistrate<O>, R extends IForgeRegistryEntry<R>, T extends R, P, S extends AbstractBuilder<O, R, T, P, S>> implements Builder<O, R, T, P, S> {
 
     @Getter(onMethod_ = {@Override})
-    private final AbstractRegistrate<?> owner;
+    private final O owner;
     @Getter(onMethod_ = {@Override})
     private final P parent;
     @Getter(onMethod_ = {@Override})
     private final String name;
     @Getter(AccessLevel.PROTECTED)
-    private final BuilderCallback callback;
+    private final BuilderCallback<O> callback;
     @Getter(onMethod_ = {@Override})
     private final ResourceKey<? extends Registry<R>> registryKey;
     
@@ -60,7 +62,7 @@ public abstract class AbstractBuilder<R extends IForgeRegistryEntry<R>, T extend
     private final LazyRegistryEntry<T> safeSupplier = new LazyRegistryEntry<>(this);
 
     @Deprecated
-    public AbstractBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Class<? super R> registryType) {
+    public AbstractBuilder(O owner, P parent, String name, BuilderCallback<O> callback, Class<? super R> registryType) {
         this(owner, parent, name, callback, owner.<R>getRegistryKeyByClass(registryType));
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -17,12 +17,15 @@ import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Registry;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -414,4 +418,161 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
     public BlockEntry<T> register() {
         return (BlockEntry<T>) super.register();
     }
+
+    /*
+        The following methods exist as shortcuts into Block Properties
+            Stops you needing to have long chains inside `properties()`
+            or having multiple `properties()` calls
+
+            ```
+            builder.properties(props -> props
+                .requiresCorrectToolForDrops()
+                .strength(3.5F)
+                .lightLevel(litBlockEmission(13)
+            )
+            ```
+
+            becomes
+
+            ```
+            builder.requiresCorrectToolForDrops()
+                .strength(3.5F)
+                .lightLevel(litBlockEmission(13)
+            ```
+     */
+    // region: Block Properties Wrappers
+    public BlockBuilder<O, T, P> noCollission()
+    {
+        return properties(BlockBehaviour.Properties::noCollission);
+    }
+
+    public BlockBuilder<O, T, P> noOcclusion()
+    {
+        return properties(BlockBehaviour.Properties::noCollission);
+    }
+
+    public BlockBuilder<O, T, P> friction(float friction)
+    {
+        return properties(properties -> properties.friction(friction));
+    }
+
+    public BlockBuilder<O, T, P> speedFactor(float speedFactor)
+    {
+        return properties(properties -> properties.speedFactor(speedFactor));
+    }
+
+    public BlockBuilder<O, T, P> jumpFactor(float jumpFactor)
+    {
+        return properties(properties -> properties.jumpFactor(jumpFactor));
+    }
+
+    public BlockBuilder<O, T, P> sound(SoundType soundType)
+    {
+        return properties(properties -> properties.sound(soundType));
+    }
+
+    public BlockBuilder<O, T, P> lightLevel(ToIntFunction<BlockState> lightEmission)
+    {
+        return properties(properties -> properties.lightLevel(lightEmission));
+    }
+
+    public BlockBuilder<O, T, P> strength(float destroyTime, float explosionResistance)
+    {
+        return properties(properties -> properties.strength(destroyTime, explosionResistance));
+    }
+
+    public BlockBuilder<O, T, P> instabreak()
+    {
+        return properties(BlockBehaviour.Properties::instabreak);
+    }
+
+    public BlockBuilder<O, T, P> strength(float strength)
+    {
+        return properties(properties -> properties.strength(strength));
+    }
+
+    public BlockBuilder<O, T, P> randomTicks()
+    {
+        return properties(BlockBehaviour.Properties::randomTicks);
+    }
+
+    public BlockBuilder<O, T, P> dynamicShape()
+    {
+        return properties(BlockBehaviour.Properties::dynamicShape);
+    }
+
+    public BlockBuilder<O, T, P> noDrops()
+    {
+        return properties(BlockBehaviour.Properties::noDrops);
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla block reasons, should never be used with custom modded blocks. Modded should use {@link #lootFrom(Supplier)}
+     */
+    @Deprecated
+    public BlockBuilder<O, T, P> dropsLike(Block block)
+    {
+        return properties(properties -> properties.dropsLike(block));
+    }
+
+    public BlockBuilder<O, T, P> lootFrom(Supplier<? extends Block> block)
+    {
+        return properties(properties -> properties.lootFrom(block));
+    }
+
+    public BlockBuilder<O, T, P> air()
+    {
+        return properties(BlockBehaviour.Properties::air);
+    }
+
+    public BlockBuilder<O, T, P> isValidSpawn(BlockBehaviour.StateArgumentPredicate<EntityType<?>> predicate)
+    {
+        return properties(properties -> properties.isValidSpawn(predicate));
+    }
+
+    public BlockBuilder<O, T, P> isRedstoneConductor(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isRedstoneConductor(predicate));
+    }
+
+    public BlockBuilder<O, T, P> isSuffocating(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isSuffocating(predicate));
+    }
+
+    public BlockBuilder<O, T, P> isViewBlocking(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.isViewBlocking(predicate));
+    }
+
+    public BlockBuilder<O, T, P> hasPostProcess(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.hasPostProcess(predicate));
+    }
+
+    public BlockBuilder<O, T, P> emissiveRendering(BlockBehaviour.StatePredicate predicate)
+    {
+        return properties(properties -> properties.emissiveRendering(predicate));
+    }
+
+    public BlockBuilder<O, T, P> requiresCorrectToolForDrops()
+    {
+        return properties(BlockBehaviour.Properties::requiresCorrectToolForDrops);
+    }
+
+    public BlockBuilder<O, T, P> color(MaterialColor materialColor)
+    {
+        return properties(properties -> properties.color(materialColor));
+    }
+
+    public BlockBuilder<O, T, P> destroyTime(float destroyTime)
+    {
+        return properties(properties -> properties.destroyTime(destroyTime));
+    }
+
+    public BlockBuilder<O, T, P> explosionResistance(float explosionResistance)
+    {
+        return properties(properties -> properties.explosionResistance(explosionResistance));
+    }
+    // endregion
 }

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -242,7 +242,7 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
      */
     public <I extends Item> ItemBuilder<O, I, BlockBuilder<O, T, P>> item(BlockItemFactory<? super T, ? extends I> factory) {
         return getOwner().<I, BlockBuilder<O, T, P>> item(this, getName(), p -> factory.create(getEntry(), p))
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop()) // FIXME Need a beetter API for "unsetting" providers
+                .clearData(ProviderType.LANG)
                 .model((ctx, prov) -> {
                     Optional<String> model = getOwner().getDataProvider(ProviderType.BLOCKSTATE)
                             .flatMap(p -> p.getExistingVariantBuilder(getEntry()))

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -3,14 +3,19 @@ package com.tterrag.registrate.builders;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import com.tterrag.registrate.AbstractRegistrate;
-import com.tterrag.registrate.builders.BlockEntityBuilder.BlockEntityFactory;
+import com.tterrag.registrate.builders.factory.BlockEntityFactory;
+import com.tterrag.registrate.builders.factory.BlockFactory;
+import com.tterrag.registrate.builders.factory.BlockItemFactory;
 import com.tterrag.registrate.providers.*;
 import com.tterrag.registrate.providers.loot.RegistrateBlockLootTables;
 import com.tterrag.registrate.providers.loot.RegistrateLootTableProvider.LootType;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.*;
+import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
+import com.tterrag.registrate.util.nullness.NonNullFunction;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 
 import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
@@ -85,12 +90,12 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
      *            The {@link Material} to use for the initial {@link Block.Properties} object
      * @return A new {@link BlockBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Block, P> BlockBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<BlockBehaviour.Properties, T> factory, Material material) {
+    public static <O extends AbstractRegistrate<O>, T extends Block, P> BlockBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, BlockFactory<T> factory, Material material) {
         return new BlockBuilder<>(owner, parent, name, callback, factory, () -> BlockBehaviour.Properties.of(material))
                 .defaultBlockstate().defaultLoot().defaultLang();
     }
 
-    private final NonNullFunction<BlockBehaviour.Properties, T> factory;
+    private final BlockFactory<T> factory;
     
     private NonNullSupplier<BlockBehaviour.Properties> initialProperties;
     private NonNullFunction<BlockBehaviour.Properties, BlockBehaviour.Properties> propertiesCallback = NonNullUnaryOperator.identity();
@@ -99,7 +104,7 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
     @Nullable
     private NonNullSupplier<Supplier<BlockColor>> colorHandler;
 
-    protected BlockBuilder(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<BlockBehaviour.Properties, T> factory, NonNullSupplier<BlockBehaviour.Properties> initialProperties) {
+    protected BlockBuilder(O owner, P parent, String name, BuilderCallback<O> callback, BlockFactory<T> factory, NonNullSupplier<BlockBehaviour.Properties> initialProperties) {
         super(owner, parent, name, callback, Registry.BLOCK_REGISTRY);
         this.factory = factory;
         this.initialProperties = initialProperties;
@@ -221,7 +226,7 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
      * @return the {@link ItemBuilder} for the {@link BlockItem}
      */
     public ItemBuilder<O, BlockItem, BlockBuilder<O, T, P>> item() {
-        return item(BlockItem::new);
+        return item(BlockItemFactory.blockItem());
     }
 
     /**
@@ -235,8 +240,8 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
      *            A factory for the item, which accepts the block object and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BlockItem}
      */
-    public <I extends Item> ItemBuilder<O, I, BlockBuilder<O, T, P>> item(NonNullBiFunction<? super T, Item.Properties, ? extends I> factory) {
-        return getOwner().<I, BlockBuilder<O, T, P>> item(this, getName(), p -> factory.apply(getEntry(), p))
+    public <I extends Item> ItemBuilder<O, I, BlockBuilder<O, T, P>> item(BlockItemFactory<? super T, ? extends I> factory) {
+        return getOwner().<I, BlockBuilder<O, T, P>> item(this, getName(), p -> factory.create(getEntry(), p))
                 .setData(ProviderType.LANG, NonNullBiConsumer.noop()) // FIXME Need a beetter API for "unsetting" providers
                 .model((ctx, prov) -> {
                     Optional<String> model = getOwner().getDataProvider(ProviderType.BLOCKSTATE)
@@ -406,7 +411,7 @@ public class BlockBuilder<O extends AbstractRegistrate<O>, T extends Block, P> e
     protected T createEntry() {
         @Nonnull BlockBehaviour.Properties properties = this.initialProperties.get();
         properties = propertiesCallback.apply(properties);
-        return factory.apply(properties);
+        return factory.create(properties);
     }
     
     @Override

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -1,13 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
@@ -29,6 +21,13 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.registries.RegistryObject;
 
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
  * A builder for block entities, allows for customization of the valid blocks.
  * 
@@ -37,7 +36,7 @@ import net.minecraftforge.registries.RegistryObject;
  * @param <P>
  *            Parent object type
  */
-public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilder<BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<T, P>> {
+public class BlockEntityBuilder<O extends AbstractRegistrate<O>, T extends BlockEntity, P> extends AbstractBuilder<O, BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<O, T, P>> {
 
     public interface BlockEntityFactory<T extends BlockEntity> {
 
@@ -66,7 +65,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            Factory to create the block entity
      * @return A new {@link BlockEntityBuilder} with reasonable default data generators.
      */
-    public static <T extends BlockEntity, P> BlockEntityBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends BlockEntity, P> BlockEntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, BlockEntityFactory<T> factory) {
         return new BlockEntityBuilder<>(owner, parent, name, callback, factory);
     }
 
@@ -75,7 +74,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
     @Nullable
     private NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer;
 
-    protected BlockEntityBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
+    protected BlockEntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, BlockEntityFactory<T> factory) {
         super(owner, parent, name, callback, Registry.BLOCK_ENTITY_TYPE_REGISTRY);
         this.factory = factory;
     }
@@ -87,7 +86,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A supplier for the block to add at registration time
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> validBlock(NonNullSupplier<? extends Block> block) {
+    public BlockEntityBuilder<O, T, P> validBlock(NonNullSupplier<? extends Block> block) {
         validBlocks.add(block);
         return this;
     }
@@ -100,7 +99,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      * @return this {@link BlockEntityBuilder}
      */
     @SafeVarargs
-    public final BlockEntityBuilder<T, P> validBlocks(NonNullSupplier<? extends Block>... blocks) {
+    public final BlockEntityBuilder<O, T, P> validBlocks(NonNullSupplier<? extends Block>... blocks) {
         Arrays.stream(blocks).forEach(this::validBlock);
         return this;
     }
@@ -115,7 +114,7 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A (server safe) supplier to an {@link Function} that will provide this block entity's renderer given the renderer dispatcher
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer) {
+    public BlockEntityBuilder<O, T, P> renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T>>> renderer) {
         if (this.renderer == null) { // First call only
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerRenderer);
         }

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.BlockEntityFactory;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -10,12 +11,10 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -37,12 +36,6 @@ import java.util.function.Supplier;
  *            Parent object type
  */
 public class BlockEntityBuilder<O extends AbstractRegistrate<O>, T extends BlockEntity, P> extends AbstractBuilder<O, BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<O, T, P>> {
-
-    public interface BlockEntityFactory<T extends BlockEntity> {
-
-        public T create(BlockEntityType<T> type, BlockPos pos, BlockState state);
-
-    }
 
     /**
      * Create a new {@link BlockEntityBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.

--- a/src/main/java/com/tterrag/registrate/builders/Builder.java
+++ b/src/main/java/com/tterrag/registrate/builders/Builder.java
@@ -128,6 +128,20 @@ public interface Builder<O extends AbstractRegistrate<O>, R extends IForgeRegist
     }
 
     /**
+     * Clear the data provider callback for this entry for the given provider type
+     *
+     * @param <D>
+     *            The type of provider
+     * @param type
+     *            The {@link ProviderType} for the desired provider
+     * @return this builder
+     */
+    default <D extends RegistrateProvider> S clearData(ProviderType<? extends D> type)
+    {
+        return setData(type, NonNullBiConsumer.noop());
+    }
+
+    /**
      * Add a data provider callback which will be invoked when the provider of the given type executes.
      * <p>
      * Calling this multiple times for the same type will <em>not</em> overwrite an existing callback.

--- a/src/main/java/com/tterrag/registrate/builders/Builder.java
+++ b/src/main/java/com/tterrag/registrate/builders/Builder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.function.Function;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
@@ -18,12 +16,16 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.function.Function;
+
 /**
  * A Builder creates registry entries. A Builder instance has a constant name which will be used for the resultant object, they cannot be reused for different names. It holds a parent object that will
  * be returned from some final methods.
  * <p>
  * When a builder is completed via {@link #register()} or {@link #build()}, the object will be lazily registered (through the owning {@link AbstractRegistrate} object).
- * 
+ *
+ * @param <O>
+ *            The type of Registrate owning the builder & compiled object.
  * @param <R>
  *            Type of the registry for the current object. This is the concrete base class that all registry entries must extend, and the type used for the forge registry itself.
  * @param <T>
@@ -33,7 +35,7 @@ import net.minecraftforge.registries.RegistryObject;
  * @param <S>
  *            Self type
  */
-public interface Builder<R extends IForgeRegistryEntry<R>, T extends R, P, S extends Builder<R, T, P, S>> extends NonNullSupplier<RegistryEntry<T>> {
+public interface Builder<O extends AbstractRegistrate<O>, R extends IForgeRegistryEntry<R>, T extends R, P, S extends Builder<O, R, T, P, S>> extends NonNullSupplier<RegistryEntry<T>> {
 
     /**
      * Complete the current entry, and return the {@link RegistryEntry} that will supply the built entry once it is available. The builder can be used afterwards, and changes made will reflect the
@@ -48,7 +50,7 @@ public interface Builder<R extends IForgeRegistryEntry<R>, T extends R, P, S ext
      * 
      * @return the owner {@link AbstractRegistrate}
      */
-    AbstractRegistrate<?> getOwner();
+    O getOwner();
 
     /**
      * The parent object.
@@ -228,7 +230,7 @@ public interface Builder<R extends IForgeRegistryEntry<R>, T extends R, P, S ext
      * @return the {@link Builder} returned by the given function
      */
     @SuppressWarnings("unchecked")
-    default <R2 extends IForgeRegistryEntry<R2>, T2 extends R2, P2, S2 extends Builder<R2, T2, P2, S2>> S2 transform(NonNullFunction<S, S2> func) {
+    default <O2 extends AbstractRegistrate<O2>, R2 extends IForgeRegistryEntry<R2>, T2 extends R2, P2, S2 extends Builder<O2, R2, T2, P2, S2>> S2 transform(NonNullFunction<S, S2> func) {
         return func.apply((S) this);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
+++ b/src/main/java/com/tterrag/registrate/builders/BuilderCallback.java
@@ -15,7 +15,7 @@ import net.minecraftforge.registries.RegistryObject;
  * A callback passed to {@link Builder builders} from the owning {@link AbstractRegistrate} which will add a registration for the built entry that lazily creates and registers it.
  */
 @FunctionalInterface
-public interface BuilderCallback {
+public interface BuilderCallback<O extends AbstractRegistrate<O>> {
 
     /**
      * Accept a built entry, to later be constructed and registered.
@@ -37,10 +37,10 @@ public interface BuilderCallback {
      * @return A {@link RegistryEntry} that will supply the registered entry
      */
     @Deprecated
-    <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
+    <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
 
     @SuppressWarnings("null")
-    default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
+    default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
         return accept(name, RegistryManager.ACTIVE.<R>getRegistry(type).getRegistrySuperType(), builder, factory, entryFactory);
     }
 
@@ -61,21 +61,21 @@ public interface BuilderCallback {
      *            A {@link NonNullSupplier} that will create the entry
      * @return A {@link RegistryEntry} that will supply the registered entry
      */
-    default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory) {
+    default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory) {
         return accept(name, type, builder, factory, delegate -> new RegistryEntry<>(builder.getOwner(), delegate));
     }
 
     @FunctionalInterface
-    public interface NewBuilderCallback extends BuilderCallback {
+    public interface NewBuilderCallback<O extends AbstractRegistrate<O>> extends BuilderCallback<O> {
 
         @SuppressWarnings("null")
         @Deprecated
         @Override
-        default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
+        default <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, Class<? super R> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory) {
             return accept(name, RegistryManager.ACTIVE.<R>getRegistry(type).getRegistryKey(), builder, factory, entryFactory);
         }
 
         @Override
-        <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
+        <R extends IForgeRegistryEntry<R>, T extends R> RegistryEntry<T> accept(String name, ResourceKey<? extends Registry<R>> type, Builder<O, R, T, ?, ?> builder, NonNullSupplier<? extends T> factory, NonNullFunction<RegistryObject<T>, ? extends RegistryEntry<T>> entryFactory);
     }
 }

--- a/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
@@ -1,8 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.Arrays;
-import java.util.EnumSet;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
@@ -13,6 +10,9 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 
+import java.util.Arrays;
+import java.util.EnumSet;
+
 /**
  * A builder for enchantments, allows for customization of the {@link Enchantment.Rarity enchantment rarity} and {@link EquipmentSlot equipment slots}, and configuration of data associated with
  * enchantments (lang).
@@ -22,7 +22,7 @@ import net.minecraft.world.item.enchantment.EnchantmentCategory;
  * @param <P>
  *            Parent object type
  */
-public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilder<Enchantment, T, P, EnchantmentBuilder<T, P>> {
+public class EnchantmentBuilder<O extends AbstractRegistrate<O>, T extends Enchantment, P> extends AbstractBuilder<O, Enchantment, T, P, EnchantmentBuilder<O, T, P>> {
 
     @FunctionalInterface
     public interface EnchantmentFactory<T extends Enchantment> {
@@ -56,7 +56,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            Factory to create the enchantment
      * @return A new {@link EnchantmentBuilder} with reasonable default data generators.
      */
-    public static <T extends Enchantment, P> EnchantmentBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends Enchantment, P> EnchantmentBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         return new EnchantmentBuilder<>(owner, parent, name, callback, type, factory)
                 .defaultLang();
     }
@@ -68,7 +68,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
 
     private final EnchantmentFactory<T> factory;
 
-    protected EnchantmentBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
+    protected EnchantmentBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EnchantmentCategory type, EnchantmentFactory<T> factory) {
         super(owner, parent, name, callback, Registry.ENCHANTMENT_REGISTRY);
         this.factory = factory;
         this.type = type;
@@ -81,7 +81,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            The rarity to assign
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> rarity(Enchantment.Rarity rarity) {
+    public EnchantmentBuilder<O, T, P> rarity(Enchantment.Rarity rarity) {
         this.rarity = rarity;
         return this;
     }
@@ -91,7 +91,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      * 
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> addArmorSlots() {
+    public EnchantmentBuilder<O, T, P> addArmorSlots() {
         return addSlots(EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET);
     }
 
@@ -102,7 +102,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            The slots to add
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> addSlots(EquipmentSlot... slots) {
+    public EnchantmentBuilder<O, T, P> addSlots(EquipmentSlot... slots) {
         this.slots.addAll(Arrays.asList(slots));
         return this;
     }
@@ -113,7 +113,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      * 
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> defaultLang() {
+    public EnchantmentBuilder<O, T, P> defaultLang() {
         return lang(Enchantment::getDescriptionId);
     }
 
@@ -124,7 +124,7 @@ public class EnchantmentBuilder<T extends Enchantment, P> extends AbstractBuilde
      *            A localized English name
      * @return this {@link EnchantmentBuilder}
      */
-    public EnchantmentBuilder<T, P> lang(String name) {
+    public EnchantmentBuilder<O, T, P> lang(String name) {
         return lang(Enchantment::getDescriptionId, name);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EnchantmentBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.EnchantmentFactory;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
@@ -23,12 +24,6 @@ import java.util.EnumSet;
  *            Parent object type
  */
 public class EnchantmentBuilder<O extends AbstractRegistrate<O>, T extends Enchantment, P> extends AbstractBuilder<O, Enchantment, T, P, EnchantmentBuilder<O, T, P>> {
-
-    @FunctionalInterface
-    public interface EnchantmentFactory<T extends Enchantment> {
-        
-        T create(Enchantment.Rarity rarity, EnchantmentCategory type, EquipmentSlot... slots);
-    }
 
     /**
      * Create a new {@link EnchantmentBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.

--- a/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.EntityTypeFactory;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
@@ -76,7 +77,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
      *            The {@link MobCategory} of the entity
      * @return A new {@link EntityBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Entity, P> EntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EntityType.EntityFactory<T> factory,
+    public static <O extends AbstractRegistrate<O>, T extends Entity, P> EntityBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, EntityTypeFactory<T> factory,
             MobCategory classification) {
         return new EntityBuilder<>(owner, parent, name, callback, factory, classification)
                 .defaultLang();
@@ -91,7 +92,7 @@ public class EntityBuilder<O extends AbstractRegistrate<O>, T extends Entity, P>
     
     private boolean attributesConfigured, spawnConfigured; // TODO make this more reuse friendly
     
-    protected EntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EntityType.EntityFactory<T> factory, MobCategory classification) {
+    protected EntityBuilder(O owner, P parent, String name, BuilderCallback<O> callback, EntityTypeFactory<T> factory, MobCategory classification) {
         super(owner, parent, name, callback, Registry.ENTITY_TYPE_REGISTRY);
         this.builder = () -> EntityType.Builder.of(factory, classification);
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -1,13 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.tterrag.registrate.AbstractRegistrate;
@@ -16,11 +8,7 @@ import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
-import com.tterrag.registrate.util.nullness.NonNullBiFunction;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullFunction;
-import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import com.tterrag.registrate.util.nullness.*;
 
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
@@ -40,6 +28,13 @@ import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.registries.RegistryObject;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
 /**
  * A builder for fluids, allows for customization of the {@link ForgeFlowingFluid.Properties} and {@link FluidAttributes}, and creation of the source variant, fluid block, and bucket item, as well as
  * data associated with fluids (tags, etc.).
@@ -49,7 +44,7 @@ import net.minecraftforge.registries.RegistryObject;
  * @param <P>
  *            Parent object type
  */
-public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilder<Fluid, T, P, FluidBuilder<T, P>> {
+public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> extends AbstractBuilder<O, Fluid, T, P, FluidBuilder<O, T, P>> {
     
     private static class Builder extends FluidAttributes.Builder {
         
@@ -78,7 +73,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null);
     }
     
@@ -104,7 +99,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, ForgeFlowingFluid.Flowing::new);
     }
@@ -133,7 +128,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
     }
@@ -172,9 +167,9 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
+        FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket()
                 .tag(FluidTags.WATER);
 
@@ -196,7 +191,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
     private NonNullSupplier<? extends ForgeFlowingFluid> source;
     private List<TagKey<Fluid>> tags = new ArrayList<>();
 
-    protected FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+    protected FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
         super(owner, parent, "flowing_" + name, callback, Registry.FLUID_REGISTRY);
         this.stillTexture = stillTexture;
@@ -218,7 +213,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
+    public FluidBuilder<O, T, P> attributes(NonNullConsumer<FluidAttributes.Builder> cons) {
         attributesCallback = attributesCallback.andThen(cons);
         return this;
     }
@@ -231,7 +226,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the properties
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> properties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
+    public FluidBuilder<O, T, P> properties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
         properties = properties.andThen(cons);
         return this;
     }
@@ -242,7 +237,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> defaultLang() {
+    public FluidBuilder<O, T, P> defaultLang() {
         return lang(f -> f.getAttributes().getTranslationKey(), RegistrateLangProvider.toEnglishName(sourceName));
     }
 
@@ -253,7 +248,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A localized English name
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> lang(String name) {
+    public FluidBuilder<O, T, P> lang(String name) {
         return lang(f -> f.getAttributes().getTranslationKey(), name);
     }
 
@@ -265,7 +260,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #source(NonNullFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultSource() {
+    public FluidBuilder<O, T, P> defaultSource() {
         if (this.defaultSource != null) {
             throw new IllegalStateException("Cannot set a default source after a custom source has been created");
         }
@@ -280,7 +275,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the fluid, which accepts the properties and returns a new fluid
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> source(NonNullFunction<ForgeFlowingFluid.Properties, ? extends ForgeFlowingFluid> factory) {
+    public FluidBuilder<O, T, P> source(NonNullFunction<ForgeFlowingFluid.Properties, ? extends ForgeFlowingFluid> factory) {
         this.defaultSource = false;
         this.source = NonNullSupplier.lazy(() -> factory.apply(makeProperties()));
         return this;
@@ -294,7 +289,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #block()} or {@link #block(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBlock() {
+    public FluidBuilder<O, T, P> defaultBlock() {
         if (this.defaultBlock != null) {
             throw new IllegalStateException("Cannot set a default block after a custom block has been created");
         }
@@ -307,7 +302,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public BlockBuilder<LiquidBlock, FluidBuilder<T, P>> block() {
+    public BlockBuilder<O, LiquidBlock, FluidBuilder<O, T, P>> block() {
         return block(LiquidBlock::new);
     }
 
@@ -320,13 +315,13 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the block, which accepts the block object and properties and returns a new block
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public <B extends LiquidBlock> BlockBuilder<B, FluidBuilder<T, P>> block(NonNullBiFunction<NonNullSupplier<? extends T>, BlockBehaviour.Properties, ? extends B> factory) {
+    public <B extends LiquidBlock> BlockBuilder<O, B, FluidBuilder<O, T, P>> block(NonNullBiFunction<NonNullSupplier<? extends T>, BlockBehaviour.Properties, ? extends B> factory) {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
         this.defaultBlock = false;
         NonNullSupplier<T> supplier = asSupplier();
-        return getOwner().<B, FluidBuilder<T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
+        return getOwner().<B, FluidBuilder<O, T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
                 .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noDrops())
                 .properties(p -> {
                     // TODO is this ok?
@@ -338,7 +333,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
     }
 
     @Beta
-    public FluidBuilder<T, P> noBlock() {
+    public FluidBuilder<O, T, P> noBlock() {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
@@ -354,7 +349,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #bucket()} or {@link #bucket(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBucket() {
+    public FluidBuilder<O, T, P> defaultBucket() {
         if (this.defaultBucket != null) {
             throw new IllegalStateException("Cannot set a default bucket after a custom bucket has been created");
         }
@@ -367,7 +362,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * 
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public ItemBuilder<BucketItem, FluidBuilder<T, P>> bucket() {
+    public ItemBuilder<O, BucketItem, FluidBuilder<O, T, P>> bucket() {
         return bucket(BucketItem::new);
     }
 
@@ -380,7 +375,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the bucket item, which accepts the fluid object supplier and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <I extends BucketItem> ItemBuilder<I, FluidBuilder<T, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
+    public <I extends BucketItem> ItemBuilder<O, I, FluidBuilder<O, T, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -389,13 +384,13 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
         if (source == null) {
             throw new IllegalStateException("Cannot create a bucket before creating a source block");
         }
-        return getOwner().<I, FluidBuilder<T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
+        return getOwner().<I, FluidBuilder<O, T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
                 .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
                 .model((ctx, prov) -> prov.generated(ctx::getEntry, new ResourceLocation(getOwner().getModid(), "item/" + bucketName)));
     }
 
     @Beta
-    public FluidBuilder<T, P> noBucket() {
+    public FluidBuilder<O, T, P> noBucket() {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -411,8 +406,8 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> tag(TagKey<Fluid>... tags) {
-        FluidBuilder<T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
+    public final FluidBuilder<O, T, P> tag(TagKey<Fluid>... tags) {
+        FluidBuilder<O, T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
             ret.getOwner().<RegistrateTagsProvider<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
                     prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
@@ -429,7 +424,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> removeTag(TagKey<Fluid>... tags) {
+    public final FluidBuilder<O, T, P> removeTag(TagKey<Fluid>... tags) {
         this.tags.removeAll(Arrays.asList(tags));
         return this.removeTag(ProviderType.FLUID_TAGS, tags);
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -9,7 +9,10 @@ import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import com.tterrag.registrate.util.entry.FluidEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
-import com.tterrag.registrate.util.nullness.*;
+import com.tterrag.registrate.util.nullness.NonNullBiFunction;
+import com.tterrag.registrate.util.nullness.NonNullConsumer;
+import com.tterrag.registrate.util.nullness.NonNullFunction;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
@@ -447,7 +450,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
         // TODO improve this?
         if (block.isPresent()) {
             attributes.translationKey(block.get().getDescriptionId());
-            setData(ProviderType.LANG, NonNullBiConsumer.noop());
+            clearData(ProviderType.LANG);
         } else {
             attributes.translationKey(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
         }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -3,6 +3,7 @@ package com.tterrag.registrate.builders;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.FluidFactory;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
@@ -71,7 +72,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, (NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes>) null);
@@ -97,11 +98,11 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param attributesFactory
      *            A factory that creates the fluid attributes instance
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, P> FluidBuilder<O, ForgeFlowingFluid.Flowing, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
             @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, ForgeFlowingFluid.Flowing::new);
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, FluidFactory.FLOWING);
     }
     
     /**
@@ -126,10 +127,10 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @param factory
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, NonNullBiFunction, FluidFactory)
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            FluidFactory<T> factory) {
         return create(owner, parent, name, callback, stillTexture, flowingTexture, null, factory);
     }
     
@@ -168,7 +169,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
     public static <O extends AbstractRegistrate<O>, T extends ForgeFlowingFluid, P> FluidBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            @Nullable NonNullBiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         FluidBuilder<O, T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, attributesFactory, factory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket()
                 .tag(FluidTags.WATER);
@@ -180,7 +181,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
     private final String sourceName;
     private final String bucketName;
     private final NonNullSupplier<FluidAttributes.Builder> attributes;
-    private final NonNullFunction<ForgeFlowingFluid.Properties, T> factory;
+    private final FluidFactory<T> factory;
 
     @Nullable
     private Boolean defaultSource, defaultBlock, defaultBucket;
@@ -192,7 +193,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
     private List<TagKey<Fluid>> tags = new ArrayList<>();
 
     protected FluidBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+            @Nullable BiFunction<FluidAttributes.Builder, Fluid, FluidAttributes> attributesFactory, FluidFactory<T> factory) {
         super(owner, parent, "flowing_" + name, callback, Registry.FLUID_REGISTRY);
         this.stillTexture = stillTexture;
         this.sourceName = name;
@@ -458,7 +459,7 @@ public class FluidBuilder<O extends AbstractRegistrate<O>, T extends ForgeFlowin
 
     @Override
     protected T createEntry() {
-        return factory.apply(makeProperties());
+        return factory.create(makeProperties());
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -13,8 +13,11 @@ import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.core.Registry;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.fml.DistExecutor;
@@ -246,4 +249,91 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     public ItemEntry<T> register() {
         return (ItemEntry<T>) super.register();
     }
+
+    /*
+        The following methods exist as shortcuts into Item Properties
+            Stops you needing to have long chains inside `properties()`
+            or having multiple `properties()` calls
+
+            ```
+            builder.properties(props -> props
+                .stacksTo(1)
+                .tab(CreativeModeTab.TAB_MISC)
+            )
+            ```
+
+            becomes
+
+            ```
+            builder.stacksTo(1).tab(CreativeModeTab.TAB_MISC)
+            ```
+     */
+    // region: Item Properties Wrappers
+    public final ItemBuilder<O, T, P> food(FoodProperties food)
+    {
+        return properties(properties -> properties.food(food));
+    }
+
+    public final ItemBuilder<O, T, P> stacksTo(int maxStackSize)
+    {
+        return properties(properties -> properties.stacksTo(maxStackSize));
+    }
+
+    public final ItemBuilder<O, T, P> defaultDurability(int durability)
+    {
+        return properties(properties -> properties.defaultDurability(durability));
+    }
+
+    public final ItemBuilder<O, T, P> durability(int durability)
+    {
+        return properties(properties -> properties.durability(durability));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla item reasons, should never be used with custom modded items. Modded should use {@link #craftRemainder(Supplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> craftRemainder(Item item)
+    {
+        return properties(properties -> properties.craftRemainder(item));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla item reasons, should never be used with custom modded items. Modded should use {@link #craftRemainder(Supplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> craftRemainder(ItemLike item)
+    {
+        return properties(properties -> properties.craftRemainder(item.asItem()));
+    }
+
+    public final ItemBuilder<O, T, P> craftRemainder(Supplier<? extends ItemLike> item)
+    {
+        return properties(properties -> properties.craftRemainder(item.get().asItem()));
+    }
+
+    /**
+     * @deprecated Exists purely for legacy & vanilla creative mode tab reasons, should never be used with custom modded creative mode tabs. Modded should use {@link #tab(NonNullSupplier)}
+     */
+    @Deprecated
+    public final ItemBuilder<O, T, P> tab(CreativeModeTab tab)
+    {
+        return properties(properties -> properties.tab(tab));
+    }
+
+    public final ItemBuilder<O, T, P> rarity(Rarity rarity)
+    {
+        return properties(properties -> properties.rarity(rarity));
+    }
+
+    public final ItemBuilder<O, T, P> fireResistant()
+    {
+        return properties(Item.Properties::fireResistant);
+    }
+
+    public final ItemBuilder<O, T, P> setNoRepair()
+    {
+        return properties(Item.Properties::setNoRepair);
+    }
+    // endregion
 }

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.builders;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.builders.factory.ItemFactory;
 import com.tterrag.registrate.providers.*;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.ItemEntry;
@@ -61,7 +62,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
      *            Factory to create the item
      * @return A new {@link ItemBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory) {
+    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory) {
         return create(owner, parent, name, callback, factory, null);
     }
     
@@ -93,13 +94,13 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
      *            The {@link CreativeModeTab} for the object, can be null for none
      * @return A new {@link ItemBuilder} with reasonable default data generators.
      */
-    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory, @Nullable NonNullSupplier<? extends CreativeModeTab> tab) {
+    public static <O extends AbstractRegistrate<O>, T extends Item, P> ItemBuilder<O, T, P> create(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory, @Nullable NonNullSupplier<? extends CreativeModeTab> tab) {
         return new ItemBuilder<>(owner, parent, name, callback, factory)
                 .defaultModel().defaultLang()
                 .transform(ib -> tab == null ? ib : ib.tab(tab));
     }
 
-    private final NonNullFunction<Item.Properties, T> factory;
+    private final ItemFactory<T> factory;
     
     private NonNullSupplier<Item.Properties> initialProperties = Item.Properties::new;
     private NonNullFunction<Item.Properties, Item.Properties> propertiesCallback = NonNullUnaryOperator.identity();
@@ -107,7 +108,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     @Nullable
     private NonNullSupplier<Supplier<ItemColor>> colorHandler;
     
-    protected ItemBuilder(O owner, P parent, String name, BuilderCallback<O> callback, NonNullFunction<Item.Properties, T> factory) {
+    protected ItemBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ItemFactory<T> factory) {
         super(owner, parent, name, callback, Registry.ITEM_REGISTRY);
         this.factory = factory;
     }
@@ -237,7 +238,7 @@ public class ItemBuilder<O extends AbstractRegistrate<O>, T extends Item, P> ext
     protected T createEntry() {
         Item.Properties properties = this.initialProperties.get();
         properties = propertiesCallback.apply(properties);
-        return factory.apply(properties);
+        return factory.create(properties);
     }
     
     @Override

--- a/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/MenuBuilder.java
@@ -1,7 +1,5 @@
 package com.tterrag.registrate.builders;
 
-import javax.annotation.Nullable;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.entry.MenuEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -22,7 +20,9 @@ import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.registries.RegistryObject;
 
-public class MenuBuilder<T extends AbstractContainerMenu, S extends Screen & MenuAccess<T>,  P> extends AbstractBuilder<MenuType<?>, MenuType<T>, P, MenuBuilder<T, S, P>> {
+import javax.annotation.Nullable;
+
+public class MenuBuilder<O extends AbstractRegistrate<O>, T extends AbstractContainerMenu, S extends Screen & MenuAccess<T>,  P> extends AbstractBuilder<O, MenuType<?>, MenuType<T>, P, MenuBuilder<O, T, S, P>> {
     
     public interface MenuFactory<T extends AbstractContainerMenu> {
         
@@ -42,11 +42,11 @@ public class MenuBuilder<T extends AbstractContainerMenu, S extends Screen & Men
     private final ForgeMenuFactory<T> factory;
     private final NonNullSupplier<ScreenFactory<T, S>> screenFactory;
 
-    public MenuBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
+    public MenuBuilder(O owner, P parent, String name, BuilderCallback<O> callback, MenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
         this(owner, parent, name, callback, (type, windowId, inv, $) -> factory.create(type, windowId, inv), screenFactory);
     }
 
-    public MenuBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
+    public MenuBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ForgeMenuFactory<T> factory, NonNullSupplier<ScreenFactory<T, S>> screenFactory) {
         super(owner, parent, name, callback, Registry.MENU_REGISTRY);
         this.factory = factory;
         this.screenFactory = screenFactory;

--- a/src/main/java/com/tterrag/registrate/builders/NoConfigBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/NoConfigBuilder.java
@@ -8,17 +8,17 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
-public class NoConfigBuilder<R extends IForgeRegistryEntry<R>, T extends R, P> extends AbstractBuilder<R, T, P, NoConfigBuilder<R, T, P>> {
+public class NoConfigBuilder<O extends AbstractRegistrate<O>, R extends IForgeRegistryEntry<R>, T extends R, P> extends AbstractBuilder<O, R, T, P, NoConfigBuilder<O, R, T, P>> {
     
     private final NonNullSupplier<T> factory;
 
-    public NoConfigBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceKey<? extends Registry<R>> registryType, NonNullSupplier<T> factory) {
+    public NoConfigBuilder(O owner, P parent, String name, BuilderCallback<O> callback, ResourceKey<? extends Registry<R>> registryType, NonNullSupplier<T> factory) {
         super(owner, parent, name, callback, registryType);
         this.factory = factory;
     }
 
     @Deprecated
-    public NoConfigBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, Class<? super R> registryType, NonNullSupplier<T> factory) {
+    public NoConfigBuilder(O owner, P parent, String name, BuilderCallback<O> callback, Class<? super R> registryType, NonNullSupplier<T> factory) {
         super(owner, parent, name, callback, registryType);
         this.factory = factory;
     }

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockEntityFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockEntityFactory.java
@@ -1,0 +1,16 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockEntityFactory<@NonnullType BLOCK_ENTITY extends BlockEntity>
+{
+	@Nonnull BLOCK_ENTITY create(@Nonnull BlockEntityType<BLOCK_ENTITY> blockEntityType, @Nonnull BlockPos pos, @Nonnull BlockState blockState);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockFactory.java
@@ -1,0 +1,16 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockFactory<@NonnullType BLOCK extends Block>
+{
+	BlockFactory<Block> BLOCK = Block::new;
+
+	@Nonnull BLOCK create(@Nonnull BlockBehaviour.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/BlockItemFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/BlockItemFactory.java
@@ -1,0 +1,20 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface BlockItemFactory<@NonnullType BLOCK extends Block, @NonnullType ITEM extends Item>
+{
+	@Nonnull ITEM create(@Nonnull BLOCK block, @Nonnull Item.Properties properties);
+
+	static <BLOCK extends Block> BlockItemFactory<BLOCK, BlockItem> blockItem()
+	{
+		return BlockItem::new;
+	}
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/EnchantmentFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/EnchantmentFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface EnchantmentFactory<@NonnullType ENCHANTMENT extends Enchantment>
+{
+	@Nonnull ENCHANTMENT create(@Nonnull Enchantment.Rarity rarity, @Nonnull EnchantmentCategory category, @Nonnull EquipmentSlot... slots);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/EntityTypeFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/EntityTypeFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface EntityTypeFactory<@NonnullType ENTITY extends Entity> extends EntityType.EntityFactory<ENTITY>
+{
+	@Override @Nonnull ENTITY create(@Nonnull EntityType<ENTITY> entityType, @Nonnull Level level);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/FluidFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/FluidFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface FluidFactory<@NonnullType FLUID extends ForgeFlowingFluid>
+{
+	FluidFactory<ForgeFlowingFluid.Flowing> FLOWING = ForgeFlowingFluid.Flowing::new;
+
+	@Nonnull FLUID create(@Nonnull ForgeFlowingFluid.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/ItemFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/ItemFactory.java
@@ -1,0 +1,15 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.world.item.Item;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface ItemFactory<@NonnullType ITEM extends Item>
+{
+	ItemFactory<Item> ITEM = Item::new;
+
+	@Nonnull ITEM create(@Nonnull Item.Properties properties);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/MenuFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/MenuFactory.java
@@ -1,0 +1,29 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.MenuType;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface MenuFactory<@NonnullType MENU extends AbstractContainerMenu>
+{
+	MENU create(@Nullable MenuType<? extends MENU> menuType, int windowId, @Nonnull Inventory playerInventory);
+
+	static <@NonnullType MENU extends AbstractContainerMenu> WithBuffer<MENU> withIgnoredBuffer(MenuFactory<MENU> menuFactory)
+	{
+		return (menuType, windowId, playerInventory, buffer) -> menuFactory.create(menuType, windowId, playerInventory);
+	}
+
+	@FunctionalInterface
+	interface WithBuffer<@NonnullType MENU extends AbstractContainerMenu>
+	{
+		MENU create(@Nullable MenuType<? extends MENU> menuType, int windowId, @NotNull Inventory playerInventory, @Nonnull FriendlyByteBuf buffer);
+	}
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/MenuScreenFactory.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/MenuScreenFactory.java
@@ -1,0 +1,17 @@
+package com.tterrag.registrate.builders.factory;
+
+import com.tterrag.registrate.util.nullness.NonnullType;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.MenuAccess;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface MenuScreenFactory<@NonnullType MENU extends AbstractContainerMenu, @NonnullType SCREEN extends Screen & MenuAccess<MENU>>
+{
+	@Nonnull SCREEN create(@Nonnull MENU menu, @Nonnull Inventory playerInventory, @Nonnull Component titleComponent);
+}

--- a/src/main/java/com/tterrag/registrate/builders/factory/package-info.java
+++ b/src/main/java/com/tterrag/registrate/builders/factory/package-info.java
@@ -1,0 +1,4 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@net.minecraft.MethodsReturnNonnullByDefault
+@com.tterrag.registrate.util.nullness.FieldsAreNonnullByDefault
+package com.tterrag.registrate.builders.factory;

--- a/src/main/java/com/tterrag/registrate/providers/DataGenContext.java
+++ b/src/main/java/com/tterrag/registrate/providers/DataGenContext.java
@@ -1,13 +1,14 @@
 package com.tterrag.registrate.providers;
 
+import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.builders.Builder;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonnullType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Delegate;
+
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -35,13 +36,13 @@ public class DataGenContext<R extends IForgeRegistryEntry<R>, E extends R> imple
         return entry.get();
     }
 
-    public static <R extends IForgeRegistryEntry<R>, E extends R> DataGenContext<R, E> from(Builder<R, E, ?, ?> builder, ResourceKey<? extends Registry<R>> type) {
+    public static <O extends AbstractRegistrate<O>, R extends IForgeRegistryEntry<R>, E extends R> DataGenContext<R, E> from(Builder<O, R, E, ?, ?> builder, ResourceKey<? extends Registry<R>> type) {
         return new DataGenContext<R, E>(NonNullSupplier.of(builder.getOwner().<R, E>get(builder.getName(), type)), builder.getName(),
                 new ResourceLocation(builder.getOwner().getModid(), builder.getName()));
     }
 
     @Deprecated
-    public static <R extends IForgeRegistryEntry<R>, E extends R> DataGenContext<R, E> from(Builder<R, E, ?, ?> builder, Class<? super R> clazz) {
+    public static <O extends AbstractRegistrate<O>, R extends IForgeRegistryEntry<R>, E extends R> DataGenContext<R, E> from(Builder<O, R, E, ?, ?> builder, Class<? super R> clazz) {
         return new DataGenContext<R, E>(NonNullSupplier.of(builder.getOwner().<R, E>get(builder.getName(), clazz)), builder.getName(),
                 new ResourceLocation(builder.getOwner().getModid(), builder.getName()));
     }

--- a/src/main/java/com/tterrag/registrate/providers/ProviderType.java
+++ b/src/main/java/com/tterrag/registrate/providers/ProviderType.java
@@ -1,10 +1,5 @@
 package com.tterrag.registrate.providers;
 
-import java.util.Map;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.loot.RegistrateLootTableProvider;
 import com.tterrag.registrate.util.nullness.FieldsAreNonnullByDefault;
@@ -13,10 +8,18 @@ import com.tterrag.registrate.util.nullness.NonNullFunction;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 
 import net.minecraft.core.Registry;
+import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.levelgen.feature.ConfiguredStructureFeature;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Map;
 
 /**
  * Represents a type of data that can be generated, and specifies a factory for the provider.
@@ -43,6 +46,9 @@ public interface ProviderType<T extends RegistrateProvider> {
     public static final ProviderType<RegistrateTagsProvider<Fluid>> FLUID_TAGS = register("tags/fluid", type -> (p, e) -> new RegistrateTagsProvider<Fluid>(p, type, "fluids", e.getGenerator(), Registry.FLUID, e.getExistingFileHelper()));
     public static final ProviderType<RegistrateTagsProvider<EntityType<?>>> ENTITY_TAGS = register("tags/entity", type -> (p, e) -> new RegistrateTagsProvider<EntityType<?>>(p, type, "entity_types", e.getGenerator(), Registry.ENTITY_TYPE, e.getExistingFileHelper()));
 
+    ProviderType<RegistrateTagsProvider<Biome>> BIOME_TAGS = register("tags/worldgen/biome", type -> (p, e) -> new RegistrateTagsProvider<Biome>(p, type, "worldgen/biome", e.getGenerator(), BuiltinRegistries.BIOME, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<ConfiguredStructureFeature<?, ?>>> CONFIGURED_STRUCTURE_FEATURE_TAGS = register("tags/worldgen/configured_structure_feature", type -> (p, e) -> new RegistrateTagsProvider<ConfiguredStructureFeature<?, ?>>(p, type, "worldgen/configured_structure_feature", e.getGenerator(), BuiltinRegistries.CONFIGURED_STRUCTURE_FEATURE, e.getExistingFileHelper()));
+    ProviderType<RegistrateTagsProvider<GameEvent>> GAME_EVENT_TAGS = register("tags/game_events", type -> (p, e) -> new RegistrateTagsProvider<GameEvent>(p, type, "game_events", e.getGenerator(), Registry.GAME_EVENT, e.getExistingFileHelper()));
     // CLIENT DATA
     public static final ProviderType<RegistrateBlockstateProvider> BLOCKSTATE = register("blockstate", (p, e) -> new RegistrateBlockstateProvider(p, e.getGenerator(), e.getExistingFileHelper()));
     public static final ProviderType<RegistrateItemModelProvider> ITEM_MODEL = register("item_model", (p, e, existing) -> new RegistrateItemModelProvider(p, e.getGenerator(), ((RegistrateBlockstateProvider)existing.get(BLOCKSTATE)).getExistingFileHelper()));

--- a/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
@@ -8,18 +8,18 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryObject;
 
-public class ItemProviderEntry<T extends IForgeRegistryEntry<? super T> & ItemLike> extends RegistryEntry<T> {
+public class ItemProviderEntry<T extends IForgeRegistryEntry<? super T> & ItemLike> extends RegistryEntry<T> implements ItemLike {
 
     public ItemProviderEntry(AbstractRegistrate<?> owner, RegistryObject<T> delegate) {
         super(owner, delegate);
     }
 
     public ItemStack asStack() {
-        return new ItemStack(get());
+        return new ItemStack(this);
     }
 
     public ItemStack asStack(int count) {
-        return new ItemStack(get(), count);
+        return new ItemStack(this, count);
     }
 
     public boolean isIn(ItemStack stack) {
@@ -28,5 +28,11 @@ public class ItemProviderEntry<T extends IForgeRegistryEntry<? super T> & ItemLi
 
     public boolean is(Item item) {
         return get().asItem() == item;
+    }
+
+    @Override
+    public Item asItem()
+    {
+        return get().asItem();
     }
 }

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -1,21 +1,11 @@
 package com.tterrag.registrate.test.mod;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
-
-import javax.annotation.Nullable;
-
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.tterrag.registrate.Registrate;
 import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.util.DataIngredient;
-import com.tterrag.registrate.util.entry.BlockEntityEntry;
-import com.tterrag.registrate.util.entry.BlockEntry;
-import com.tterrag.registrate.util.entry.EntityEntry;
-import com.tterrag.registrate.util.entry.FluidEntry;
-import com.tterrag.registrate.util.entry.ItemEntry;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.tterrag.registrate.util.entry.*;
 import com.tterrag.registrate.util.nullness.NonnullType;
 
 import net.minecraft.advancements.Advancement;
@@ -55,11 +45,7 @@ import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantment.Rarity;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
@@ -92,6 +78,10 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryBuilder;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 @Mod("testmod")
 public class TestMod {
@@ -361,7 +351,7 @@ public class TestMod {
 //            .block(Block::new)
 //            .addLayer(() -> RenderType::getTranslucent);
     
-    private static <T extends Block, P> @NonnullType BlockBuilder<T, P> applyDiamondDrop(BlockBuilder<T, P> builder) {
+    private static <T extends Block, P> @NonnullType BlockBuilder<Registrate, T, P> applyDiamondDrop(BlockBuilder<Registrate, T, P> builder) {
         return builder.loot((prov, block) -> prov.dropOther(block, Items.DIAMOND));
     }
 


### PR DESCRIPTION
### This PR is simply a duplicate of #46 but downported for _Minecraft: **1.18**_.

---

This PR brings various quality of life changes to Registrate which I used to make use of in a seperate child of mod Registrate called Registrator, This just merges the 2 into Registrate.

These changes consit of the following
- All builders now have a generic reference to their AbstractRegistrate owner, this means builders know exactly what registrate type owns them.
    - Useful only for custom registrate types that have new methods, this change allows calling those methods without needing to cast the builders owner property.
- Provider types for the new & missing vanilla tag types
- Implements ItemLike onto ItemProviderEntry so that it can be passed into places that expect an ItemLike object
    - ItemStack constructor is good example for this use case
- Added functional factory interfaces for each builder type
    - This change is not so necessary, but makes reading code and lambdas easier to eye, imo
- Shortcut methods inside of various builder to their property builder classes
    - ItemBuilder, BlockBuilder, EntityTypeBuilder
    - These methods remove the need to chain calls inside of .properties() or call .properties() multiple times
- Easy method to quickly clear a data provider callback for a given builder