### PR TITLE
Forge 1.19.3 Updates & CreativeModeTabs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.daemon=false
 
 mod_version=1.1.x
 minecraft_version=1.19.3
-forge_version=44.0.0
+forge_version=44.0.23

--- a/src/generated/resources/.cache/cb324306540a4b4c26483f8aac3bb4c7234f8610
+++ b/src/generated/resources/.cache/cb324306540a4b4c26483f8aac3bb4c7234f8610
@@ -1,9 +1,9 @@
-// 1.19.3	2022-12-10T05:50:38.7651973	Registrate Provider for testmod [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.19.3	2022-12-16T03:02:46.9080446	Registrate Provider for testmod [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 353e0134b90278ff49840165bed05cb48e7fff1b assets/testmod/blockstates/magic_item_model.json
 bc6ecd9ef8452b21567c005ab9c626c54a1beeaa assets/testmod/blockstates/testblock.json
 069fa0cc9495cbad97a129b3e39bd0bdf0599b28 assets/testmod/blockstates/testfluid.json
-5a6966380a9641fb31f35fe8fc9964e5015c318b assets/testmod/lang/en_ud.json
-8b69c8e0e7b41eae83a4b85609d070c9ac02b079 assets/testmod/lang/en_us.json
+abeeba673d336192695a050607ff25f96eeec9d0 assets/testmod/lang/en_ud.json
+59a0ee505bfcde1044dd6b417085dee203d8cf08 assets/testmod/lang/en_us.json
 b3c7ac87f735c9813d09ee46f1d26c844c06353c assets/testmod/models/block/subfolder/magic_item_model.json
 226ecfcb53fb775aa96f550dcc41bc44c026127f assets/testmod/models/block/testblock.json
 c73682ddea9998e48415b962e3c3b1d2dcc6157a assets/testmod/models/block/testfluid.json

--- a/src/generated/resources/assets/testmod/lang/en_ud.json
+++ b/src/generated/resources/assets/testmod/lang/en_ud.json
@@ -11,7 +11,7 @@
   "item.testmod.testentity_spawn_egg": "bbƎ uʍɐdS ʎʇıʇuǝʇsǝ⟘",
   "item.testmod.testitem": "ɯǝʇıʇsǝ⟘",
   "item.testmod.testitem.testextra": "¡ɔıbɐW",
-  "itemGroup.testmod": "poW ʇsǝ⟘",
+  "itemGroup.testmod.test_creative_mode_tab": "poW ʇsǝ⟘",
   "testmod.custom.lang": "ʇsǝ⟘",
   "tooltip.testmod.testblock": "˙bbƎ"
 }

--- a/src/generated/resources/assets/testmod/lang/en_us.json
+++ b/src/generated/resources/assets/testmod/lang/en_us.json
@@ -11,7 +11,7 @@
   "item.testmod.testentity_spawn_egg": "Testentity Spawn Egg",
   "item.testmod.testitem": "Testitem",
   "item.testmod.testitem.testextra": "Magic!",
-  "itemGroup.testmod": "Test Mod",
+  "itemGroup.testmod.test_creative_mode_tab": "Test Mod",
   "testmod.custom.lang": "Test",
   "tooltip.testmod.testblock": "Egg."
 }

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -12,6 +12,7 @@ import com.tterrag.registrate.builders.MenuBuilder.ScreenFactory;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateDataProvider;
 import com.tterrag.registrate.providers.RegistrateProvider;
+import com.tterrag.registrate.util.CreativeModeTabModifier;
 import com.tterrag.registrate.util.DebugMarkers;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -35,14 +36,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType.EntityFactory;
 import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
-import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -64,7 +62,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -121,39 +122,6 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         void addRegisterCallback(NonNullConsumer<? super T> callback) {
             Preconditions.checkNotNull(callback, "Callback must not be null");
             callbacks.add(callback);
-        }
-    }
-
-    public static final class CreativeModeTabModifier implements CreativeModeTab.Output {
-        private final Supplier<FeatureFlagSet> flags;
-        private final BooleanSupplier hasPermissions;
-        private final BiConsumer<ItemStack, CreativeModeTab.TabVisibility> acceptFunc;
-
-        private CreativeModeTabModifier(Supplier<FeatureFlagSet> flags, BooleanSupplier hasPermissions, BiConsumer<ItemStack, CreativeModeTab.TabVisibility> acceptFunc) {
-            this.flags = flags;
-            this.hasPermissions = hasPermissions;
-            this.acceptFunc = acceptFunc;
-        }
-
-        public FeatureFlagSet getFlags() {
-            return flags.get();
-        }
-
-        public boolean hasPermissions() {
-            return hasPermissions.getAsBoolean();
-        }
-
-        @Override
-        public void accept(ItemStack stack, CreativeModeTab.TabVisibility visibility) {
-            acceptFunc.accept(stack, visibility);
-        }
-
-        public void accept(Supplier<? extends ItemLike> item, CreativeModeTab.TabVisibility visibility) {
-            accept(item.get(), visibility);
-        }
-
-        public void accept(Supplier<? extends ItemLike> item) {
-            accept(item.get());
         }
     }
 

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -664,6 +664,29 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return self();
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Using the {@code beforeEntries} & {@code afterEntries} you can specify what other {@link CreativeModeTab tabs} must come before or after this tab.<br>
+     * These lists can contain the following: {@link String} | {@link ResourceLocation} in from of a tab RegistryName or a {@link CreativeModeTab} instance
+     * <p>
+     * You can specify an optional {@code englishTranslation} translation value to be auto-generated and assigned as this tabs display name via {@link Component#translatable(String)}
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param beforeEntries List of entries to come before this tab
+     * @param afterEntries List of entries to come after this tab
+     * @param configurator The configurator used to build this tab
+     * @param englishTranslation Optional English (US) translation to auto-generate & assign as this tabs display name
+     * @return Reference to the newly registered tab
+     * @implNote The returned (lazy) {@link Supplier} will be autofilled in later during the {@link CreativeModeTabEvent.Register} event,
+     * if you try to obtain the tab before then a {@link NullPointerException} will be thrown due to the tab being registered yet.
+     */
     public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
         var internalName = new ResourceLocation(modid, registryName);
 
@@ -678,43 +701,210 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return result;
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Using the {@code beforeEntries} & {@code afterEntries} you can specify what other {@link CreativeModeTab tabs} must come before or after this tab.<br>
+     * These lists can contain the following: {@link String} | {@link ResourceLocation} in from of a tab RegistryName or a {@link CreativeModeTab} instance
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param beforeEntries List of entries to come before this tab
+     * @param afterEntries List of entries to come after this tab
+     * @param configurator The configurator used to build this tab
+     * @return Reference to the newly registered tab
+     * @implNote The returned (lazy) {@link Supplier} will be autofilled in later during the {@link CreativeModeTabEvent.Register} event,
+     * if you try to obtain the tab before then a {@link NullPointerException} will be thrown due to the tab being registered yet.
+     * @see #buildCreativeModeTab(String, List, List, Consumer, String)
+     */
     public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator) {
         return buildCreativeModeTab(registryName, beforeEntries, afterEntries, configurator, null);
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param configurator The configurator used to build this tab
+     * @return Reference to the newly registered tab
+     * @implNote The returned (lazy) {@link Supplier} will be autofilled in later during the {@link CreativeModeTabEvent.Register} event,
+     * if you try to obtain the tab before then a {@link NullPointerException} will be thrown due to the tab being registered yet.
+     * @see #buildCreativeModeTab(String, List, List, Consumer, String)
+     */
     public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator) {
         return buildCreativeModeTab(registryName, null, null, configurator);
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * You can specify an optional {@code englishTranslation} translation value to be auto-generated and assigned as this tabs display name via {@link Component#translatable(String)}
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param configurator The configurator used to build this tab
+     * @return Reference to the newly registered tab
+     * @implNote The returned (lazy) {@link Supplier} will be autofilled in later during the {@link CreativeModeTabEvent.Register} event,
+     * if you try to obtain the tab before then a {@link NullPointerException} will be thrown due to the tab being registered yet.
+     * @see #buildCreativeModeTab(String, List, List, Consumer, String)
+     */
     public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
         return buildCreativeModeTab(registryName, null, null, configurator, englishTranslation);
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Using the {@code beforeEntries} & {@code afterEntries} you can specify what other {@link CreativeModeTab tabs} must come before or after this tab.<br>
+     * These lists can contain the following: {@link String} | {@link ResourceLocation} in from of a tab RegistryName or a {@link CreativeModeTab} instance
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     * <p>
+     * This method does not return a reference to the newly registered {@link CreativeModeTab} but you can still obtain one using {@link net.minecraftforge.common.CreativeModeTabRegistry#getTab(ResourceLocation)}
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param beforeEntries List of entries to come before this tab
+     * @param afterEntries List of entries to come after this tab
+     * @param configurator The configurator used to build this tab
+     * @return This {@link AbstractRegistrate} instance, to allow method chaining
+     * @see #buildCreativeModeTab(String, List, List, Consumer)
+     * @implNote This is functionally the same as calling {@link #buildCreativeModeTab(String, List, List, Consumer)}, but rather than returning a reference to the newly registered tab,
+     * we return the registrate instance to allow method chaining
+     */
     public S creativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator) {
         buildCreativeModeTab(registryName, beforeEntries, afterEntries, configurator);
         return self();
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Using the {@code beforeEntries} & {@code afterEntries} you can specify what other {@link CreativeModeTab tabs} must come before or after this tab.<br>
+     * These lists can contain the following: {@link String} | {@link ResourceLocation} in from of a tab RegistryName or a {@link CreativeModeTab} instance
+     * <p>
+     * You can specify an optional {@code englishTranslation} translation value to be auto-generated and assigned as this tabs display name via {@link Component#translatable(String)}
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     * <p>
+     * This method does not return a reference to the newly registered {@link CreativeModeTab} but you can still obtain one using {@link net.minecraftforge.common.CreativeModeTabRegistry#getTab(ResourceLocation)}
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param beforeEntries List of entries to come before this tab
+     * @param afterEntries List of entries to come after this tab
+     * @param configurator The configurator used to build this tab
+     * @param englishTranslation Optional English (US) translation to auto-generate & assign as this tabs display name
+     * @return This {@link AbstractRegistrate} instance, to allow method chaining
+     * @see #buildCreativeModeTab(String, List, List, Consumer, String)
+     * @implNote This is functionally the same as calling {@link #buildCreativeModeTab(String, List, List, Consumer, String)}, but rather than returning a reference to the newly registered tab,
+     * we return the registrate instance to allow method chaining
+     */
     public S creativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
         buildCreativeModeTab(registryName, beforeEntries, afterEntries, configurator, englishTranslation);
         return self();
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     * <p>
+     * This method does not return a reference to the newly registered {@link CreativeModeTab} but you can still obtain one using {@link net.minecraftforge.common.CreativeModeTabRegistry#getTab(ResourceLocation)}
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param configurator The configurator used to build this tab
+     * @return This {@link AbstractRegistrate} instance, to allow method chaining
+     * @see #buildCreativeModeTab(String, Consumer)
+     * @implNote This is functionally the same as calling {@link #buildCreativeModeTab(String, Consumer)}, but rather than returning a reference to the newly registered tab,
+     * we return the registrate instance to allow method chaining
+     */
     public S creativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator) {
         buildCreativeModeTab(registryName, configurator);
         return self();
     }
 
+    /**
+     * Register a new CreativeModeTab with the given properties & name.
+     *
+     * <p>
+     * Registeres a new {@link CreativeModeTab} with the given properties and registry name [under Registrates supplied namespace].<br>
+     * The newly registered tab is marked as Registrates default tab, if one does not already exist [This is passed onto future builders to preset their tab properties].
+     * <p>
+     * You can specify an optional {@code englishTranslation} translation value to be auto-generated and assigned as this tabs display name via {@link Component#translatable(String)}
+     * <p>
+     * Multiple calls to this method with the same registry name is not supported, and should only be called once per new tab type
+     * <p>
+     * This method does not return a reference to the newly registered {@link CreativeModeTab} but you can still obtain one using {@link net.minecraftforge.common.CreativeModeTabRegistry#getTab(ResourceLocation)}
+     *
+     * @param registryName The registry name for this tab [Must pass ResourceLocation {@code path} validation]
+     * @param configurator The configurator used to build this tab
+     * @return This {@link AbstractRegistrate} instance, to allow method chaining
+     * @see #buildCreativeModeTab(String, Consumer, String)
+     * @implNote This is functionally the same as calling {@link #buildCreativeModeTab(String, Consumer, String)}, but rather than returning a reference to the newly registered tab,
+     * we return the registrate instance to allow method chaining
+     */
     public S creativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
         buildCreativeModeTab(registryName, configurator, englishTranslation);
         return self();
     }
 
+    /**
+     * Set the default CreativeModeTab to be passed onto future builders.
+     *
+     * <p>
+     * This marks a {@link CreativeModeTab} as the default tab to be used when constructing new builder classes,
+     * this allows those builders to be preset with a given tab automatically, rather than needing to manually set it yourself.
+     * <p>
+     * This is called when registering a new {@link CreativeModeTab} type via {@link #buildCreativeModeTab(String, List, List, Consumer, String)}, if a default tab has not already been set.
+     *
+     * @param creativeModeTab The new default CreativeModeTab type
+     * @return This {@link AbstractRegistrate} instance
+     */
     public S creativeModeTab(Supplier<? extends CreativeModeTab> creativeModeTab) {
         defaultCreativeModeTab = creativeModeTab;
         return self();
     }
 
+    /**
+     * Registeres a new modifier callback to be used to modify the given CreativeModeTab.
+     *
+     * <p>
+     * Registeres a new callback to be invoked during the {@link CreativeModeTabEvent.BuildContents} event and
+     * used to modify what items are displayed on the given {@link CreativeModeTab}.
+     * <p>
+     * Calling this method multiple times will replace previously registered callbacks.
+     *
+     * @param creativeModeTab The {@link CreativeModeTab} to register this callback for
+     * @param modifier The modifier callback to be registered
+     * @return This {@link AbstractRegistrate} instance
+     */
     public S modifyCreativeModeTab(Supplier<? extends CreativeModeTab> creativeModeTab, Consumer<CreativeModeTabModifier> modifier) {
         creativeModeTabModifiers.put(creativeModeTab, modifier);
         return self();

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -38,7 +38,6 @@ import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -58,6 +57,7 @@ import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import net.minecraftforge.registries.*;
 
 import javax.annotation.Nonnull;
@@ -158,7 +158,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     }
 
     private static final class CreativeModeTabRegistration implements Supplier<CreativeModeTab> {
-        private static final Supplier<List<Object>> DEFAULT_AFTER_ENTRIES = Lazy.of(CreativeModeTabRegistration::defaultAfterEntries);
+        private static final Supplier<List<Object>> DEFAULT_AFTER_ENTRIES = Lazy.of(() -> ObfuscationReflectionHelper.getPrivateValue(CreativeModeTabEvent.class, null, "DEFAULT_AFTER_ENTRIES"));
 
         @Nullable private CreativeModeTab creativeModeTab = null;
         private final ResourceLocation registryName;
@@ -181,19 +181,6 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         @Override
         public CreativeModeTab get() {
             return Objects.requireNonNull(creativeModeTab, () -> "Attempt to obtain CreativeModeTab(%s) instance before it was registered!".formatted(registryName));
-        }
-
-        @SuppressWarnings("unchecked")
-        private static List<Object> defaultAfterEntries() {
-            try {
-                var field = CreativeModeTabEvent.class.getDeclaredField("DEFAULT_AFTER_ENTRIES");
-                field.setAccessible(true);
-                return (List<Object>) field.get(null);
-            }
-            catch(NoSuchFieldException | IllegalAccessException e) {
-                log.fatal("Error occurred while obtaining CreativeModeTabEvent#DEFAULT_AFTER_ENTRIES", e);
-                return List.of(CreativeModeTabs.SPAWN_EGGS); // Match value from CreativeModeTabEvent
-            }
         }
     }
 

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -677,15 +677,30 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return self();
     }
 
-    public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator) {
-        var result = new CreativeModeTabRegistration(new ResourceLocation(modid, registryName), beforeEntries, afterEntries, configurator);
+    public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
+        var internalName = new ResourceLocation(modid, registryName);
+
+        if(englishTranslation != null) {
+            var component = addLang("itemGroup", internalName, englishTranslation);
+            configurator = configurator.andThen(builder -> builder.title(component));
+        }
+
+        var result = new CreativeModeTabRegistration(internalName, beforeEntries, afterEntries, configurator);
         creativeModeTabsRegistrars.add(result);
         if(defaultCreativeModeTab == null) defaultCreativeModeTab = result;
         return result;
     }
 
+    public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator) {
+        return buildCreativeModeTab(registryName, beforeEntries, afterEntries, configurator, null);
+    }
+
     public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator) {
         return buildCreativeModeTab(registryName, null, null, configurator);
+    }
+
+    public Supplier<CreativeModeTab> buildCreativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
+        return buildCreativeModeTab(registryName, null, null, configurator, englishTranslation);
     }
 
     public S creativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator) {
@@ -693,8 +708,18 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return self();
     }
 
+    public S creativeModeTab(String registryName, @Nullable List<Object> beforeEntries, @Nullable List<Object> afterEntries, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
+        buildCreativeModeTab(registryName, beforeEntries, afterEntries, configurator, englishTranslation);
+        return self();
+    }
+
     public S creativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator) {
         buildCreativeModeTab(registryName, configurator);
+        return self();
+    }
+
+    public S creativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
+        buildCreativeModeTab(registryName, configurator, englishTranslation);
         return self();
     }
 

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -212,7 +212,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
     private final ListMultimap<ProviderType<?>, @NonnullType NonNullConsumer<? extends RegistrateProvider>> datagens = ArrayListMultimap.create();
     private final Map<Supplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabModifiers = Maps.newHashMap();
     private final List<CreativeModeTabRegistration> creativeModeTabsRegistrars = Lists.newArrayList();
-    @Nullable private Supplier<CreativeModeTab> defaultCreativeModeTab = null;
+    @Nullable private Supplier<? extends CreativeModeTab> defaultCreativeModeTab = null;
 
     private final NonNullSupplier<Boolean> doDatagen = NonNullSupplier.lazy(DatagenModLoader::isRunningDataGen);
 
@@ -687,7 +687,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
         var result = new CreativeModeTabRegistration(internalName, beforeEntries, afterEntries, configurator);
         creativeModeTabsRegistrars.add(result);
-        if(defaultCreativeModeTab == null) defaultCreativeModeTab = result;
+        if(defaultCreativeModeTab == null) creativeModeTab(result);
         return result;
     }
 
@@ -720,6 +720,11 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     public S creativeModeTab(String registryName, Consumer<CreativeModeTab.Builder> configurator, @Nullable String englishTranslation) {
         buildCreativeModeTab(registryName, configurator, englishTranslation);
+        return self();
+    }
+
+    public S creativeModeTab(Supplier<? extends CreativeModeTab> creativeModeTab) {
+        defaultCreativeModeTab = creativeModeTab;
         return self();
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -3,6 +3,7 @@ package com.tterrag.registrate.builders;
 import com.google.common.collect.Maps;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.*;
+import com.tterrag.registrate.util.CreativeModeTabModifier;
 import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -109,7 +110,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
 
     @Nullable
     private NonNullSupplier<Supplier<ItemColor>> colorHandler;
-    private Map<NonNullSupplier<? extends CreativeModeTab>, Consumer<AbstractRegistrate.CreativeModeTabModifier>> creativeModeTabs = Maps.newHashMap();
+    private Map<NonNullSupplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabs = Maps.newHashMap();
 
     protected ItemBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<Item.Properties, T> factory) {
         super(owner, parent, name, callback, ForgeRegistries.Keys.ITEMS);
@@ -161,10 +162,10 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * Calling this method multiple times with the same {@link NonNullSupplier tab supplier} will replace any previous calls.
      *
      * @param tab The {@link CreativeModeTab} to add the item into
-     * @param modifier The {@link com.tterrag.registrate.AbstractRegistrate.CreativeModeTabModifier} used to build the ItemStack
+     * @param modifier The {@link CreativeModeTabModifier} used to build the ItemStack
      * @return This builder
      */
-    public ItemBuilder<T, P> tab(NonNullSupplier<? extends CreativeModeTab> tab, Consumer<AbstractRegistrate.CreativeModeTabModifier> modifier) {
+    public ItemBuilder<T, P> tab(NonNullSupplier<? extends CreativeModeTab> tab, Consumer<CreativeModeTabModifier> modifier) {
         creativeModeTabs.put(tab, modifier); // Should we get the current value in the map [if one exists] and .andThen() the 2 together? right now we replace any consumer that currently exists
         return this;
     }

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -158,7 +158,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
     protected void onBuildCreativeModeTabContents(CreativeModeTabEvent.BuildContents event) {
         if(tab == null) return;
         var tab = this.tab.get();
-        if(tab != null) event.registerSimple(tab, getEntry());
+        if(tab != null && event.getTab() == tab) event.accept(get());
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/providers/ProviderType.java
+++ b/src/main/java/com/tterrag/registrate/providers/ProviderType.java
@@ -43,9 +43,9 @@ public interface ProviderType<T extends RegistrateProvider> {
     public static final ProviderType<RegistrateTagsProvider<EntityType<?>>> ENTITY_TAGS = register("tags/entity", type -> (p, e) -> new RegistrateTagsProvider<EntityType<?>>(p, type, "entity_types", e.getGenerator().getPackOutput(), Registries.ENTITY_TYPE, e.getLookupProvider(), e.getExistingFileHelper()));
 
     // CLIENT DATA
-    public static final ProviderType<RegistrateBlockstateProvider> BLOCKSTATE = register("blockstate", (p, e) -> new RegistrateBlockstateProvider(p, e.getGenerator(), e.getExistingFileHelper()));
-    public static final ProviderType<RegistrateItemModelProvider> ITEM_MODEL = register("item_model", (p, e, existing) -> new RegistrateItemModelProvider(p, e.getGenerator(), ((RegistrateBlockstateProvider)existing.get(BLOCKSTATE)).getExistingFileHelper()));
-    public static final ProviderType<RegistrateLangProvider> LANG = register("lang", (p, e) -> new RegistrateLangProvider(p, e.getGenerator()));
+    public static final ProviderType<RegistrateBlockstateProvider> BLOCKSTATE = register("blockstate", (p, e) -> new RegistrateBlockstateProvider(p, e.getGenerator().getPackOutput(), e.getExistingFileHelper()));
+    public static final ProviderType<RegistrateItemModelProvider> ITEM_MODEL = register("item_model", (p, e, existing) -> new RegistrateItemModelProvider(p, e.getGenerator().getPackOutput(), ((RegistrateBlockstateProvider)existing.get(BLOCKSTATE)).getExistingFileHelper()));
+    public static final ProviderType<RegistrateLangProvider> LANG = register("lang", (p, e) -> new RegistrateLangProvider(p, e.getGenerator().getPackOutput()));
 
     T create(AbstractRegistrate<?> parent, GatherDataEvent event, Map<ProviderType<?>, RegistrateProvider> existing);
 

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateBlockstateProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateBlockstateProvider.java
@@ -1,10 +1,8 @@
 package com.tterrag.registrate.providers;
 
-import java.util.Optional;
-
 import com.tterrag.registrate.AbstractRegistrate;
 
-import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.client.model.generators.BlockStateProvider;
 import net.minecraftforge.client.model.generators.MultiPartBlockStateBuilder;
@@ -12,12 +10,14 @@ import net.minecraftforge.client.model.generators.VariantBlockStateBuilder;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.fml.LogicalSide;
 
+import java.util.Optional;
+
 public class RegistrateBlockstateProvider extends BlockStateProvider implements RegistrateProvider {
 
     private final AbstractRegistrate<?> parent;
 
-    public RegistrateBlockstateProvider(AbstractRegistrate<?> parent, DataGenerator gen, ExistingFileHelper exFileHelper) {
-        super(gen, parent.getModid(), exFileHelper);
+    public RegistrateBlockstateProvider(AbstractRegistrate<?> parent, PackOutput packOutput, ExistingFileHelper exFileHelper) {
+        super(packOutput, parent.getModid(), exFileHelper);
         this.parent = parent;
     }
 
@@ -30,23 +30,23 @@ public class RegistrateBlockstateProvider extends BlockStateProvider implements 
     protected void registerStatesAndModels() {
         parent.genData(ProviderType.BLOCKSTATE, this);
     }
-    
+
     @Override
     public String getName() {
         return "Blockstates";
     }
-    
+
     ExistingFileHelper getExistingFileHelper() {
         return this.models().existingFileHelper;
     }
-    
+
     @SuppressWarnings("null")
     public Optional<VariantBlockStateBuilder> getExistingVariantBuilder(Block block) {
         return Optional.ofNullable(registeredBlocks.get(block))
                 .filter(b -> b instanceof VariantBlockStateBuilder)
                 .map(b -> (VariantBlockStateBuilder) b);
     }
-    
+
     @SuppressWarnings("null")
     public Optional<MultiPartBlockStateBuilder> getExistingMultipartBuilder(Block block) {
         return Optional.ofNullable(registeredBlocks.get(block))

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateItemModelProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateItemModelProvider.java
@@ -3,8 +3,7 @@ package com.tterrag.registrate.providers;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
-import net.minecraft.core.Registry;
-import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.client.model.generators.ItemModelBuilder;
@@ -15,11 +14,11 @@ import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class RegistrateItemModelProvider extends ItemModelProvider implements RegistrateProvider {
-    
+
     private final AbstractRegistrate<?> parent;
 
-    public RegistrateItemModelProvider(AbstractRegistrate<?> parent, DataGenerator generator, ExistingFileHelper existingFileHelper) {
-        super(generator, parent.getModid(), existingFileHelper);
+    public RegistrateItemModelProvider(AbstractRegistrate<?> parent, PackOutput packOutput, ExistingFileHelper existingFileHelper) {
+        super(packOutput, parent.getModid(), existingFileHelper);
         this.parent = parent;
     }
 
@@ -27,33 +26,33 @@ public class RegistrateItemModelProvider extends ItemModelProvider implements Re
     public LogicalSide getSide() {
         return LogicalSide.CLIENT;
     }
-    
+
     @Override
     protected void registerModels() {
         parent.genData(ProviderType.ITEM_MODEL, this);
     }
-    
+
     @Override
     public String getName() {
         return "Item models";
     }
-    
+
     public String modid(NonNullSupplier<? extends ItemLike> item) {
         return ForgeRegistries.ITEMS.getKey(item.get().asItem()).getNamespace();
     }
-    
+
     public String name(NonNullSupplier<? extends ItemLike> item) {
         return ForgeRegistries.ITEMS.getKey(item.get().asItem()).getPath();
     }
-    
+
     public ResourceLocation itemTexture(NonNullSupplier<? extends ItemLike> item) {
         return modLoc("item/" + name(item));
     }
-    
+
     public ItemModelBuilder blockItem(NonNullSupplier<? extends ItemLike> block) {
         return blockItem(block, "");
     }
-    
+
     public ItemModelBuilder blockItem(NonNullSupplier<? extends ItemLike> block, String suffix) {
         return withExistingParent(name(block), new ResourceLocation(modid(block), "block/" + name(block) + suffix));
     }
@@ -61,15 +60,15 @@ public class RegistrateItemModelProvider extends ItemModelProvider implements Re
     public ItemModelBuilder blockWithInventoryModel(NonNullSupplier<? extends ItemLike> block) {
         return withExistingParent(name(block), new ResourceLocation(modid(block), "block/" + name(block) + "_inventory"));
     }
-    
+
     public ItemModelBuilder blockSprite(NonNullSupplier<? extends ItemLike> block) {
         return blockSprite(block, modLoc("block/" + name(block)));
     }
-    
+
     public ItemModelBuilder blockSprite(NonNullSupplier<? extends ItemLike> block, ResourceLocation texture) {
         return generated(() -> block.get().asItem(), texture);
     }
-    
+
     public ItemModelBuilder generated(NonNullSupplier<? extends ItemLike> item) {
         return generated(item, itemTexture(item));
     }
@@ -81,11 +80,11 @@ public class RegistrateItemModelProvider extends ItemModelProvider implements Re
         }
         return ret;
     }
-    
+
     public ItemModelBuilder handheld(NonNullSupplier<? extends ItemLike> item) {
         return handheld(item, itemTexture(item));
     }
-    
+
     public ItemModelBuilder handheld(NonNullSupplier<? extends ItemLike> item, ResourceLocation texture) {
         return withExistingParent(name(item), "item/handheld").texture("layer0", texture);
     }

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
@@ -9,7 +9,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.CachedOutput;
-import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.EntityType;
@@ -31,8 +31,8 @@ public class RegistrateLangProvider extends LanguageProvider implements Registra
 
     private static class AccessibleLanguageProvider extends LanguageProvider {
 
-        public AccessibleLanguageProvider(DataGenerator gen, String modid, String locale) {
-            super(gen, modid, locale);
+        public AccessibleLanguageProvider(PackOutput packOutput, String modid, String locale) {
+            super(packOutput, modid, locale);
         }
 
         @Override
@@ -48,10 +48,10 @@ public class RegistrateLangProvider extends LanguageProvider implements Registra
 
     private final AccessibleLanguageProvider upsideDown;
 
-    public RegistrateLangProvider(AbstractRegistrate<?> owner, DataGenerator gen) {
-        super(gen, owner.getModid(), "en_us");
+    public RegistrateLangProvider(AbstractRegistrate<?> owner, PackOutput packOutput) {
+        super(packOutput, owner.getModid(), "en_us");
         this.owner = owner;
-        this.upsideDown = new AccessibleLanguageProvider(gen, owner.getModid(), "en_ud");
+        this.upsideDown = new AccessibleLanguageProvider(packOutput, owner.getModid(), "en_ud");
     }
 
     @Override

--- a/src/main/java/com/tterrag/registrate/util/CreativeModeTabModifier.java
+++ b/src/main/java/com/tterrag/registrate/util/CreativeModeTabModifier.java
@@ -1,0 +1,46 @@
+package com.tterrag.registrate.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public final class CreativeModeTabModifier implements CreativeModeTab.Output {
+    private final Supplier<FeatureFlagSet> flags;
+    private final BooleanSupplier hasPermissions;
+    private final BiConsumer<ItemStack, CreativeModeTab.TabVisibility> acceptFunc;
+
+    @ApiStatus.Internal
+    public CreativeModeTabModifier(Supplier<FeatureFlagSet> flags, BooleanSupplier hasPermissions, BiConsumer<ItemStack, CreativeModeTab.TabVisibility> acceptFunc) {
+        this.flags = flags;
+        this.hasPermissions = hasPermissions;
+        this.acceptFunc = acceptFunc;
+    }
+
+    public FeatureFlagSet getFlags() {
+        return flags.get();
+    }
+
+    public boolean hasPermissions() {
+        return hasPermissions.getAsBoolean();
+    }
+
+    @Override
+    public void accept(ItemStack stack, CreativeModeTab.TabVisibility visibility) {
+        acceptFunc.accept(stack, visibility);
+    }
+
+    public void accept(Supplier<? extends ItemLike> item, CreativeModeTab.TabVisibility visibility) {
+        accept(item.get(), visibility);
+    }
+
+    public void accept(Supplier<? extends ItemLike> item) {
+        accept(item.get());
+    }
+}

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -71,7 +71,6 @@ import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.CreativeModeTabEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
@@ -83,7 +82,6 @@ import net.minecraftforge.registries.RegistryBuilder;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 @Mod("testmod")
@@ -184,9 +182,16 @@ public class TestMod {
 
     private static class TestCustomRegistryEntry {}
 
-    private AtomicReference<CreativeModeTab> modTab = new AtomicReference<>();
-
-    private final Registrate registrate = Registrate.create("testmod").creativeModeTab(modTab::get, "Test Mod");
+    private final Registrate registrate = Registrate
+            .create("testmod")
+            .creativeModeTab("test_creative_mode_tab", c -> c
+                    .title(Component.translatable("itemGroup.testmod"))
+                    .icon(Items.STONE::getDefaultInstance)
+            )
+            // TODO: Auto add these when registering new CreativeModeTabs
+            //  Should also update RegistrateLangProvider to check if CreativeModeTab translation component is translatable,
+            //  they used to always be translatable in the past but this is not the case anymore
+            .addDataGenerator(ProviderType.LANG, provider -> provider.add("itemGroup.testmod", "Test Mod"));
 
     private final AtomicBoolean sawCallback = new AtomicBoolean();
 
@@ -376,7 +381,6 @@ public class TestMod {
         });
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::registerCreativeTab);
         MinecraftForge.EVENT_BUS.addListener(this::afterServerStart);
     }
 
@@ -393,19 +397,5 @@ public class TestMod {
     }
 
     private void afterServerStart(ServerStartedEvent event) {
-    }
-
-    private void registerCreativeTab(CreativeModeTabEvent.Register event) {
-        var result = event.registerCreativeModeTab(new ResourceLocation("testmod", "test_creative_mode_tab"), builder -> builder
-                .title(Component.translatable("itemGroup.testmod"))
-                /*.displayItems((flagSet, output, showOp) -> registrate
-                        .getAll(Registries.ITEM)
-                        .stream()
-                        .map(RegistryEntry::get)
-                        .forEach(output::accept)
-                )*/
-        );
-
-        modTab.set(result);
     }
 }

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -184,14 +184,7 @@ public class TestMod {
 
     private final Registrate registrate = Registrate
             .create("testmod")
-            .creativeModeTab("test_creative_mode_tab", c -> c
-                    .title(Component.translatable("itemGroup.testmod"))
-                    .icon(Items.STONE::getDefaultInstance)
-            )
-            // TODO: Auto add these when registering new CreativeModeTabs
-            //  Should also update RegistrateLangProvider to check if CreativeModeTab translation component is translatable,
-            //  they used to always be translatable in the past but this is not the case anymore
-            .addDataGenerator(ProviderType.LANG, provider -> provider.add("itemGroup.testmod", "Test Mod"));
+            .creativeModeTab("test_creative_mode_tab", c -> c.icon(Items.STONE::getDefaultInstance), "Test Mod");
 
     private final AtomicBoolean sawCallback = new AtomicBoolean();
 


### PR DESCRIPTION
This PR brings the needed changes to run on the recent Forge 1.19.3 versions & adds a new CreativeModeTab registration system to match Forge's CreativeModeTab events.

Updated data-gens to all take in `PackOutput` rather than `DataGenerator` to match Forge & Vanilla

Added methods to create, register & modify CreativeModeTabs
- `AbstractRegistrate#buildCreativeModeTab(String, [@Nullable List<Object>], [@Nullable List<Object>], Consumer<CreativeModeTab.Builder>, [@Nullable String])`
	- Used to build & register a new CreativeModeTab
	- Marks the first registered CreativeModeTab as the 'defaultTab', this is passed across to any 
'ItemBuilder' objects to pre-set the items display tab
	- Returns lazy-supplier to the registered instance (filled in later during registration)
	- Optional parameter to auto register translatable components for the tabs display name
- `AbstractRegistrate#creativeModeTab(String, [@Nullable List<Object>], [@Nullable List<Object>], Consumer<CreativeModeTab.Builder>, [@Nullable String])`
	- The same as `#buildCreativeModeTab` but returns the Registrate instance to allow method chaining
- `AbstractRegistrate#creativeModeTab(Supplier<? extends CreativeModeTab>)`
	- Used to set the default CreativeModeTab instance
- `AbstractRegistrate#modifyCreativeModeTab(Supplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>)`
	- Used to register callbacks which are used to modify what items are displayed on the given tab
- `ItemBuilder#tab(NonNullSupplier<? extends CreativeModeTab>, [Consumer<AbstractRegistrate.CreativeModeTabModifier>])`
	- Used to display the item built from this builder on the given tab
	- Optional consumer parameter to modify the ItemStack instance
- `ItemBuilder#removeTab(NonNullSupplier<? extends CreativeModeTab>)`
	- Used to remove the item built from this builder from the given tab