### PR TITLE
Fix issue where creative tab modification order was not preserved

### DIFF
--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -165,7 +165,7 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     private final Table<Pair<String, ResourceKey<? extends Registry<?>>>, ProviderType<?>, Consumer<? extends RegistrateProvider>> datagensByEntry = HashBasedTable.create();
     private final ListMultimap<ProviderType<?>, @NonnullType NonNullConsumer<? extends RegistrateProvider>> datagens = ArrayListMultimap.create();
-    private final Map<Supplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabModifiers = Maps.newHashMap();
+    private final Map<Supplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabModifiers = Maps.newLinkedHashMap();
     private final List<CreativeModeTabRegistration> creativeModeTabsRegistrars = Lists.newArrayList();
     @Nullable private Supplier<? extends CreativeModeTab> defaultCreativeModeTab = null;
 

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -110,7 +110,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
 
     @Nullable
     private NonNullSupplier<Supplier<ItemColor>> colorHandler;
-    private Map<NonNullSupplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabs = Maps.newHashMap();
+    private Map<NonNullSupplier<? extends CreativeModeTab>, Consumer<CreativeModeTabModifier>> creativeModeTabs = Maps.newLinkedHashMap();
 
     protected ItemBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<Item.Properties, T> factory) {
         super(owner, parent, name, callback, ForgeRegistries.Keys.ITEMS);


### PR DESCRIPTION
Fixes issue causing items to display in random slots on creative tabs, caused by creative tab modification registrations not preserving the order in which they were registered.

<details>
<summary><b>Before</b></summary>  
<img src="https://user-images.githubusercontent.com/29412632/217161344-a8afa358-8b32-4996-8680-5e489ef441e4.png"/>
</details>

<details>
<summary><b>After</b></summary>
<img src="https://user-images.githubusercontent.com/29412632/217161380-62b7df3e-c89b-4ac2-b778-2b813b5f972b.png"/>
</details>