### PR TITLE
Fix Fluids

### DIFF
--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -1046,21 +1046,21 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return fluid(self(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(
-            ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S>
+    fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+          NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return fluid(self(), stillTexture, flowingTexture, sourceFactory, flowingFactory);
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(
-            ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S>
+    fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+          NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory);
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S>
+    fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+          NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return fluid(self(), stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory);
     }
 
@@ -1166,23 +1166,20 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidType));
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
-            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P>
+    fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, sourceFactory, flowingFactory));
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
-            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P>
+    fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+          NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory));
     }
 
-    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
-            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
-            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P>
+    fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+          NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory));
     }
 

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -1022,160 +1022,168 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     // Fluids
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid() {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid() {
         return fluid(self());
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(FluidBuilder.FluidTypeFactory typeFactory) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), typeFactory);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(NonNullSupplier<FluidType> fluidType) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), fluidType);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), stillTexture, flowingTexture);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-            NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), stillTexture, flowingTexture, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(
+            ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), stillTexture, flowingTexture, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), stillTexture, flowingTexture, typeFactory, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(
+            ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), stillTexture, flowingTexture, fluidType, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid> FluidBuilder<TSource, TFlowing, S> fluid(ResourceLocation stillTexture, ResourceLocation flowingTexture,
+            NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name) {
         return fluid(self(), name);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, typeFactory);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, NonNullSupplier<FluidType> fluidType) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, fluidType);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, typeFactory);
     }
 
-    public FluidBuilder<ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), name, stillTexture, flowingTexture, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), name, stillTexture, flowingTexture, typeFactory, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid> FluidBuilder<T, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(self(), name, stillTexture, flowingTexture, fluidType, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, S> fluid(String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(self(), name, stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent) {
         return fluid(parent, currentName());
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), typeFactory);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, NonNullSupplier<FluidType> fluidType) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), fluidType);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory);
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType, fluidFactory);
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(P parent, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name) {
         return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"));
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"), typeFactory);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, name, new ResourceLocation(getModid(), "block/" + currentName() + "_still"), new ResourceLocation(getModid(), "block/" + currentName() + "_flow"), fluidType);
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture));
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, typeFactory));
     }
 
-    public <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidType));
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidFactory));
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
+            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, sourceFactory, flowingFactory));
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, typeFactory, fluidFactory));
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
+            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory));
     }
 
-    public <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidType, fluidFactory));
+    public <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> fluid(
+            P parent, String name, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory));
     }
 
     // Menu

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilder<Fluid, T, P, FluidBuilder<T, P>> {
+public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> extends AbstractBuilder<Fluid, TSource, P, FluidBuilder<TSource, TFlowing, P>> {
 
     @FunctionalInterface
     public interface FluidTypeFactory {
@@ -65,10 +65,10 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, ForgeFlowingFluid.Flowing::new);
+    public static <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, ForgeFlowingFluid.Source::new, ForgeFlowingFluid.Flowing::new);
     }
 
     /**
@@ -91,10 +91,10 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, ForgeFlowingFluid.Flowing::new);
+    public static <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, ForgeFlowingFluid.Source::new, ForgeFlowingFluid.Flowing::new);
     }
 
     /**
@@ -117,17 +117,19 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @param flowingTexture
      *            The texture to use for flowing fluids
      * @return A new {@link FluidBuilder} with reasonable default data generators.
-     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction)
+     * @see #create(AbstractRegistrate, Object, String, BuilderCallback, ResourceLocation, ResourceLocation, FluidTypeFactory, NonNullFunction, NonNullFunction)
      */
-    public static <P> FluidBuilder<ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, ForgeFlowingFluid.Flowing::new);
+    public static <P> FluidBuilder<ForgeFlowingFluid.Source, ForgeFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, ForgeFlowingFluid.Source::new, ForgeFlowingFluid.Flowing::new);
     }
 
     /**
      * Create a new {@link FluidBuilder} and configure data. The created builder will use a default ({@link FluidType}) and fluid class ({@link ForgeFlowingFluid.Flowing}).
      *
-     * @param <T>
-     *            The type of the builder
+     * @param <TSource>>
+     *            The source fluid type
+     * @param <TFlowing>
+     *            The flowing fluid type
      * @param <P>
      *            Parent object type
      * @param owner
@@ -142,13 +144,15 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The texture to use for still fluids
      * @param flowingTexture
      *            The texture to use for flowing fluids
-     * @param fluidFactory
-     *            A factory that creates the flowing fluid
+     * @param sourceFactory
+     *            A factory that creates the source fluid
+     * @param flowingFactory
+     *            A factory that creates the source fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, fluidFactory);
+    public static <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        return create(owner, parent, name, callback, stillTexture, flowingTexture, FluidBuilder::defaultFluidType, sourceFactory, flowingFactory);
     }
 
     /**
@@ -157,13 +161,14 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * The fluid will be assigned the following data:
      * <ul>
      * <li>The default translation (via {@link #defaultLang()})</li>
-     * <li>A default {@link ForgeFlowingFluid.Source source fluid} (via {@link #defaultSource})</li>
      * <li>A default block for the fluid, with its own default blockstate and model that configure the particle texture (via {@link #defaultBlock()})</li>
      * <li>A default bucket item, that uses a simple generated item model with a texture of the same name as this fluid (via {@link #defaultBucket()})</li>
      * </ul>
      *
-     * @param <T>
-     *            The type of the builder
+     * @param <TSource>>
+     *            The source fluid type
+     * @param <TFlowing>
+     *            The flowing fluid type
      * @param <P>
      *            Parent object type
      * @param owner
@@ -180,14 +185,16 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The texture to use for flowing fluids
      * @param typeFactory
      *            A factory that creates the fluid type
-     * @param fluidFactory
-     *            A factory that creates the flowing fluid
+     * @param sourceFactory
+     *            A factory that creates the source fluid
+     * @param flowingFactory
+     *            A factory that creates the source fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, fluidFactory)
-            .defaultLang().defaultSource().defaultBlock().defaultBucket();
+    public static <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
+        FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        FluidBuilder<TSource, TFlowing, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, sourceFactory, flowingFactory)
+            .defaultLang().defaultBlock().defaultBucket();
         return ret;
     }
 
@@ -197,13 +204,14 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * The fluid will be assigned the following data:
      * <ul>
      * <li>The default translation (via {@link #defaultLang()})</li>
-     * <li>A default {@link ForgeFlowingFluid.Source source fluid} (via {@link #defaultSource})</li>
      * <li>A default block for the fluid, with its own default blockstate and model that configure the particle texture (via {@link #defaultBlock()})</li>
      * <li>A default bucket item, that uses a simple generated item model with a texture of the same name as this fluid (via {@link #defaultBucket()})</li>
      * </ul>
      *
-     * @param <T>
-     *            The type of the builder
+     * @param <TSource>>
+     *            The source fluid type
+     * @param <TFlowing>
+     *            The flowing fluid type
      * @param <P>
      *            Parent object type
      * @param owner
@@ -220,47 +228,56 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The texture to use for flowing fluids
      * @param fluidType
      *            An existing and registered fluid type
-     * @param fluidFactory
-     *            A factory that creates the flowing fluid
+     * @param sourceFactory
+     *            A factory that creates the source fluid
+     * @param flowingFactory
+     *            A factory that creates the source fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends ForgeFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture,
-        NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, fluidFactory)
-                .defaultLang().defaultSource().defaultBlock().defaultBucket();
+    public static <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> create(
+            AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
+            ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        FluidBuilder<TSource, TFlowing, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory)
+                .defaultLang().defaultBlock().defaultBucket();
         return ret;
     }
 
-    private final String sourceName, bucketName;
+    private final String flowingName, bucketName;
 
     private final ResourceLocation stillTexture, flowingTexture;
-    private final NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory;
+    private final NonNullFunction<ForgeFlowingFluid.Properties, ? extends TSource> sourceFactory;
+    private final NonNullFunction<ForgeFlowingFluid.Properties, ? extends TFlowing> flowingFactory;
 
     @Nullable
     private final NonNullSupplier<FluidType> fluidType;
 
     @Nullable
-    private Boolean defaultSource, defaultBlock, defaultBucket;
+    private Boolean defaultBlock, defaultBucket;
 
     private NonNullConsumer<FluidType.Properties> typeProperties = $ -> {};
 
     private NonNullConsumer<ForgeFlowingFluid.Properties> fluidProperties;
 
-    private @Nullable Supplier<RenderType> layer = null;
+    private @Nullable Supplier<Supplier<RenderType>> layer = null;
 
     private boolean registerType;
 
-    @Nullable
-    private NonNullSupplier<? extends ForgeFlowingFluid> source;
+    private NonNullSupplier<TFlowing> flowingFluid;
     private final List<TagKey<Fluid>> tags = new ArrayList<>();
 
-    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        super(owner, parent, "flowing_" + name, callback, ForgeRegistries.Keys.FLUIDS);
-        this.sourceName = name;
+    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
+                        ResourceLocation flowingTexture, FluidTypeFactory typeFactory,
+                        NonNullFunction<ForgeFlowingFluid.Properties, ? extends TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, ? extends TFlowing> flowingFactory) {
+        super(owner, parent, name, callback, ForgeRegistries.Keys.FLUIDS);
+        this.flowingName = "flowing_" + name;
         this.bucketName = name + "_bucket";
         this.stillTexture = stillTexture;
         this.flowingTexture = flowingTexture;
-        this.fluidFactory = fluidFactory;
+        this.sourceFactory = sourceFactory;
+        this.flowingFactory = flowingFactory;
+        this.flowingFluid = NonNullSupplier.lazy(() -> this.flowingFactory.apply(makeProperties()));
         this.fluidType = NonNullSupplier.lazy(() -> typeFactory.create(makeTypeProperties(), this.stillTexture, this.flowingTexture));
         this.registerType = true;
 
@@ -269,17 +286,23 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
             .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
     }
 
-    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType, NonNullFunction<ForgeFlowingFluid.Properties, T> fluidFactory) {
-        super(owner, parent, "flowing_" + name, callback, ForgeRegistries.Keys.FLUIDS);
-        this.sourceName = name;
+    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
+                        ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
+                        NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
+                        NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+        super(owner, parent, name, callback, ForgeRegistries.Keys.FLUIDS);
+        this.flowingName = "flowing_" + name;
         this.bucketName = name + "_bucket";
         this.stillTexture = stillTexture;
         this.flowingTexture = flowingTexture;
-        this.fluidFactory = fluidFactory;
+        this.sourceFactory = sourceFactory;
+        this.flowingFactory = flowingFactory;
         this.fluidType = fluidType;
         this.registerType = false; // Don't register if we have a fluid from outside.
 
         String bucketName = this.bucketName;
+
+        // TODO: I'm very not happy with how this was done.
         this.fluidProperties = p -> p.bucket(() -> owner.get(bucketName, ForgeRegistries.Keys.ITEMS).get())
                 .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
     }
@@ -292,7 +315,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> properties(NonNullConsumer<FluidType.Properties> cons) {
+    public FluidBuilder<TSource, TFlowing, P> properties(NonNullConsumer<FluidType.Properties> cons) {
         typeProperties = typeProperties.andThen(cons);
         return this;
     }
@@ -305,7 +328,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> fluidProperties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
+    public FluidBuilder<TSource, TFlowing, P> fluidProperties(NonNullConsumer<ForgeFlowingFluid.Properties> cons) {
         fluidProperties = fluidProperties.andThen(cons);
         return this;
     }
@@ -316,8 +339,8 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> defaultLang() {
-        return lang(f -> f.getFluidType().getDescriptionId(), RegistrateLangProvider.toEnglishName(sourceName));
+    public FluidBuilder<TSource, TFlowing, P> defaultLang() {
+        return lang(f -> f.getFluidType().getDescriptionId(), RegistrateLangProvider.toEnglishName(getName()));
     }
 
     /**
@@ -327,14 +350,14 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A localized English name
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> lang(String name) {
+    public FluidBuilder<TSource, TFlowing, P> lang(String name) {
         return lang(f -> f.getFluidType().getDescriptionId(), name);
     }
 
     @SuppressWarnings("deprecation")
-    public FluidBuilder<T, P> renderType(Supplier<RenderType> layer) {
+    public FluidBuilder<TSource, TFlowing, P> renderType(Supplier<Supplier<RenderType>> layer) {
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-            Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(layer.get()), "Invalid render type: " + layer);
+            Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(layer.get().get()), "Invalid render type: " + layer);
         });
 
         if (this.layer == null) {
@@ -345,45 +368,16 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
     }
 
     @SuppressWarnings("deprecation")
-    protected void registerRenderType(T entry) {
+    protected void registerRenderType(TSource entry) {
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
             OneTimeEventReceiver.addModListener(getOwner(), FMLClientSetupEvent.class, $ -> {
                 if (this.layer != null) {
-                    RenderType layer = this.layer.get();
+                    RenderType layer = this.layer.get().get();
                     ItemBlockRenderTypes.setRenderLayer(entry, layer);
-                    ItemBlockRenderTypes.setRenderLayer(getSource(), layer);
+                    ItemBlockRenderTypes.setRenderLayer(flowingFluid.get(), layer);
                 }
             });
         });
-    }
-
-    /**
-     * Create a standard {@link ForgeFlowingFluid.Source} for this fluid which will be built and registered along with this fluid.
-     *
-     * @return this {@link FluidBuilder}
-     * @see #source(NonNullFunction)
-     * @throws IllegalStateException
-     *             If {@link #source(NonNullFunction)} has been called before this method
-     */
-    public FluidBuilder<T, P> defaultSource() {
-        if (this.defaultSource != null) {
-            throw new IllegalStateException("Cannot set a default source after a custom source has been created");
-        }
-        this.defaultSource = true;
-        return this;
-    }
-
-    /**
-     * Create a {@link ForgeFlowingFluid} for this fluid, which is created by the given factory, and which will be built and registered along with this fluid.
-     *
-     * @param factory
-     *            A factory for the fluid, which accepts the properties and returns a new fluid
-     * @return this {@link FluidBuilder}
-     */
-    public FluidBuilder<T, P> source(NonNullFunction<ForgeFlowingFluid.Properties, ? extends ForgeFlowingFluid> factory) {
-        this.defaultSource = false;
-        this.source = NonNullSupplier.lazy(() -> factory.apply(makeProperties()));
-        return this;
     }
 
     /**
@@ -394,7 +388,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #block()} or {@link #block(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBlock() {
+    public FluidBuilder<TSource, TFlowing, P> defaultBlock() {
         if (this.defaultBlock != null) {
             throw new IllegalStateException("Cannot set a default block after a custom block has been created");
         }
@@ -407,7 +401,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public BlockBuilder<LiquidBlock, FluidBuilder<T, P>> block() {
+    public BlockBuilder<LiquidBlock, FluidBuilder<TSource, TFlowing, P>> block() {
         return block(LiquidBlock::new);
     }
 
@@ -420,21 +414,21 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the block, which accepts the block object and properties and returns a new block
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public <B extends LiquidBlock> BlockBuilder<B, FluidBuilder<T, P>> block(NonNullBiFunction<NonNullSupplier<? extends T>, BlockBehaviour.Properties, ? extends B> factory) {
+    public <B extends LiquidBlock> BlockBuilder<B, FluidBuilder<TSource, TFlowing, P>> block(NonNullBiFunction<NonNullSupplier<? extends TSource>, BlockBehaviour.Properties, ? extends B> factory) {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
         this.defaultBlock = false;
-        NonNullSupplier<T> supplier = asSupplier();
-        return getOwner().<B, FluidBuilder<T, P>>block(this, sourceName, p -> factory.apply(supplier, p))
+        NonNullSupplier<TSource> supplier = asSupplier();
+        return getOwner().<B, FluidBuilder<TSource, TFlowing, P>>block(this, getName(), p -> factory.apply(supplier, p))
             .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noLootTable())
             .properties(p -> p.lightLevel(blockState -> fluidType.get().getLightLevel()))
-            .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(sourceName)
+            .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(getName())
                 .texture("particle", stillTexture)));
     }
 
     @Beta
-    public FluidBuilder<T, P> noBlock() {
+    public FluidBuilder<TSource, TFlowing, P> noBlock() {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
@@ -450,7 +444,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @throws IllegalStateException
      *             If {@link #bucket()} or {@link #bucket(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBucket() {
+    public FluidBuilder<TSource, TFlowing, P> defaultBucket() {
         if (this.defaultBucket != null) {
             throw new IllegalStateException("Cannot set a default bucket after a custom bucket has been created");
         }
@@ -463,7 +457,7 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public ItemBuilder<BucketItem, FluidBuilder<T, P>> bucket() {
+    public ItemBuilder<BucketItem, FluidBuilder<TSource, TFlowing, P>> bucket() {
         return bucket(BucketItem::new);
     }
 
@@ -476,23 +470,19 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      *            A factory for the bucket item, which accepts the fluid object supplier and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <I extends BucketItem> ItemBuilder<I, FluidBuilder<T, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
+    public <I extends BucketItem> ItemBuilder<I, FluidBuilder<TSource, TFlowing, P>> bucket(NonNullBiFunction<Supplier<? extends ForgeFlowingFluid>, Item.Properties, ? extends I> factory) {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
         this.defaultBucket = false;
-        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
-        // TODO: Can we find a way to circumvent this limitation?
-        if (source == null) {
-            throw new IllegalStateException("Cannot create a bucket before creating a source block");
-        }
-        return getOwner().<I, FluidBuilder<T, P>>item(this, bucketName, p -> factory.apply(source::get, p))
+
+        return getOwner().<I, FluidBuilder<TSource, TFlowing, P>>item(this, bucketName, p -> factory.apply(() -> get().get(), p))
             .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
             .model((ctx, prov) -> prov.generated(ctx::getEntry, new ResourceLocation(getOwner().getModid(), "item/" + bucketName)));
     }
 
     @Beta
-    public FluidBuilder<T, P> noBucket() {
+    public FluidBuilder<TSource, TFlowing, P> noBucket() {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -508,11 +498,11 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> tag(TagKey<Fluid>... tags) {
-        FluidBuilder<T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
+    public final FluidBuilder<TSource, TFlowing, P> tag(TagKey<Fluid>... tags) {
+        FluidBuilder<TSource, TFlowing, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
-            ret.getOwner().<RegistrateTagsProvider<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
-                prov -> this.tags.stream().map(prov::addTag).forEach(p -> p.add(getSource().builtInRegistryHolder().key())));
+            ret.getOwner().<RegistrateTagsProvider<Fluid>, Fluid>setDataGenerator(ret.flowingName, getRegistryKey(), ProviderType.FLUID_TAGS,
+                prov -> this.tags.stream().map(prov::addTag).forEach(p -> p.add(ret.flowingFluid.get().builtInRegistryHolder().key())));
         }
         this.tags.addAll(Arrays.asList(tags));
         return ret;
@@ -526,27 +516,20 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> removeTag(TagKey<Fluid>... tags) {
+    public final FluidBuilder<TSource, TFlowing, P> removeTag(TagKey<Fluid>... tags) {
         this.tags.removeAll(Arrays.asList(tags));
         return this.removeTag(ProviderType.FLUID_TAGS, tags);
     }
 
-    private ForgeFlowingFluid getSource() {
-        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
-        Preconditions.checkNotNull(source, "Fluid has no source block: " + sourceName);
-        return source.get();
-    }
-
     private ForgeFlowingFluid.Properties makeProperties() {
-        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
-        ForgeFlowingFluid.Properties ret = new ForgeFlowingFluid.Properties(fluidType, source == null ? null : source::get, asSupplier());
+        ForgeFlowingFluid.Properties ret = new ForgeFlowingFluid.Properties(fluidType, asSupplier(), flowingFluid);
         fluidProperties.accept(ret);
         return ret;
     }
 
     private FluidType.Properties makeTypeProperties() {
         FluidType.Properties properties = FluidType.Properties.create();
-        RegistryEntry<Block> block = getOwner().getOptional(sourceName, ForgeRegistries.Keys.BLOCKS);
+        RegistryEntry<Block> block = getOwner().getOptional(getName(), ForgeRegistries.Keys.BLOCKS);
         this.typeProperties.accept(properties);
 
         // Force the translation key after the user callback runs
@@ -558,15 +541,15 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
             properties.descriptionId(block.get().getDescriptionId());
             setData(ProviderType.LANG, NonNullBiConsumer.noop());
         } else {
-            properties.descriptionId(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), sourceName)));
+            properties.descriptionId(Util.makeDescriptionId("fluid", new ResourceLocation(getOwner().getModid(), getName())));
         }
 
         return properties;
     }
 
     @Override
-    protected T createEntry() {
-        return fluidFactory.apply(makeProperties());
+    protected TSource createEntry() {
+        return sourceFactory.apply(makeProperties());
     }
 
     /**
@@ -576,20 +559,17 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public FluidEntry<T> register() {
+    public FluidEntry<TSource> register() {
         // Check the fluid has a type.
         if (this.fluidType != null) {
             // Register the type.
             if (this.registerType) {
-                getOwner().simple(this, this.sourceName, ForgeRegistries.Keys.FLUID_TYPES, this.fluidType);
+                getOwner().simple(this, getName(), ForgeRegistries.Keys.FLUID_TYPES, this.fluidType);
             }
         } else {
             throw new IllegalStateException("Fluid must have a type: " + getName());
         }
 
-        if (defaultSource == Boolean.TRUE) {
-            source(ForgeFlowingFluid.Source::new);
-        }
         if (defaultBlock == Boolean.TRUE) {
             block().register();
         }
@@ -597,18 +577,13 @@ public class FluidBuilder<T extends ForgeFlowingFluid, P> extends AbstractBuilde
             bucket().register();
         }
 
-        NonNullSupplier<? extends ForgeFlowingFluid> source = this.source;
-        if (source != null) {
-            getCallback().accept(sourceName, ForgeRegistries.Keys.FLUIDS, (FluidBuilder) this, source::get);
-        } else {
-            throw new IllegalStateException("Fluid must have a source version: " + getName());
-        }
+        getCallback().accept(flowingName, ForgeRegistries.Keys.FLUIDS, (FluidBuilder) this, flowingFluid);
 
-        return (FluidEntry<T>) super.register();
+        return (FluidEntry<TSource>) super.register();
     }
 
     @Override
-    protected RegistryEntry<T> createEntryWrapper(RegistryObject<T> delegate) {
+    protected RegistryEntry<TSource> createEntryWrapper(RegistryObject<TSource> delegate) {
         return new FluidEntry<>(getOwner(), delegate);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -427,6 +427,9 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
+
+        // Remove block lookup
+        this.fluidProperties = p -> p.block(null);
         this.defaultBlock = false;
         return this;
     }
@@ -481,6 +484,9 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
+
+        // Disable bucket lookup
+        fluidProperties = p -> p.bucket(null);
         this.defaultBucket = false;
         return this;
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -235,10 +235,8 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
     public static <TSource extends ForgeFlowingFluid, TFlowing extends ForgeFlowingFluid, P> FluidBuilder<TSource, TFlowing, P> create(
-            AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
-            ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
-            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-            NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+            AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
+            NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         FluidBuilder<TSource, TFlowing, P> ret = new FluidBuilder<>(owner, parent, name, callback, stillTexture, flowingTexture, fluidType, sourceFactory, flowingFactory)
                 .defaultLang().defaultBlock().defaultBucket();
         return ret;
@@ -267,8 +265,7 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
     private NonNullSupplier<TFlowing> flowingFluid;
     private final List<TagKey<Fluid>> tags = new ArrayList<>();
 
-    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
-                        ResourceLocation flowingTexture, FluidTypeFactory typeFactory,
+    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidTypeFactory typeFactory,
                         NonNullFunction<ForgeFlowingFluid.Properties, ? extends TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, ? extends TFlowing> flowingFactory) {
         super(owner, parent, name, callback, ForgeRegistries.Keys.FLUIDS);
         this.flowingName = "flowing_" + name;
@@ -286,10 +283,8 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
             .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
     }
 
-    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture,
-                        ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
-                        NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory,
-                        NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
+    public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, ResourceLocation stillTexture, ResourceLocation flowingTexture, NonNullSupplier<FluidType> fluidType,
+                        NonNullFunction<ForgeFlowingFluid.Properties, TSource> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, TFlowing> flowingFactory) {
         super(owner, parent, name, callback, ForgeRegistries.Keys.FLUIDS);
         this.flowingName = "flowing_" + name;
         this.bucketName = name + "_bucket";

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -296,8 +296,6 @@ public class FluidBuilder<TSource extends ForgeFlowingFluid, TFlowing extends Fo
         this.registerType = false; // Don't register if we have a fluid from outside.
 
         String bucketName = this.bucketName;
-
-        // TODO: I'm very not happy with how this was done.
         this.fluidProperties = p -> p.bucket(() -> owner.get(bucketName, ForgeRegistries.Keys.ITEMS).get())
                 .block(() -> owner.<Block, LiquidBlock>get(name, ForgeRegistries.Keys.BLOCKS).get());
     }

--- a/src/main/java/com/tterrag/registrate/util/entry/FluidEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/FluidEntry.java
@@ -33,8 +33,8 @@ public class FluidEntry<T extends ForgeFlowingFluid> extends RegistryEntry<T> {
     }
 
     @SuppressWarnings("unchecked")
-    public <S extends ForgeFlowingFluid> S getSource() {
-        return (S) get().getSource();
+    public <S extends ForgeFlowingFluid> S getFlowing() {
+        return (S) get().getFlowing();
     }
 
     public FluidType getType() {

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -268,7 +268,7 @@ public class TestMod {
             .blockEntity(TestDummyBlockEntity::new)
             .register();
 
-    private final FluidEntry<ForgeFlowingFluid.Flowing> testfluid = registrate.object("testfluid")
+    private final FluidEntry<ForgeFlowingFluid.Source> testfluid = registrate.object("testfluid")
             .fluid(new ResourceLocation("block/water_flow"), new ResourceLocation("block/lava_still"), (props, still, flow) -> new FluidType(props) {
                 // And now you can do custom behaviours.
                 @Override
@@ -287,7 +287,7 @@ public class TestMod {
                 }
             })
             .properties(p -> p.lightLevel(15).canConvertToSource(true))
-            .renderType(RenderType::translucent)
+            .renderType(() -> RenderType::translucent)
             .noBucket()
 //            .bucket()
 //                .model((ctx, prov) -> prov.withExistingParent(ctx.getName(), prov.mcLoc("item/water_bucket")))


### PR DESCRIPTION
This PR addresses a handful of concerns with the original implementation.

1. Fixed FluidEntry<>#getBlock -> This would always would query for modname:flowing_fluid_name instead of modname:fluid_name. Fixed this by making the FluidBuilder create both the source and flowing (and swapped the order) without any extra builder calls.
2. Fixes fluid render types - applied the same fix as for blocks etc., it just needed to have another supplier around it to fix server-side support.
3. More sensible fluid properties - we unset the bucket and block suppliers now if noBucket/noBlock is called

This could be considered breaking as the API has shifted slightly, so might want to bump major version :)