### PR TITLE
Fix placeholders in upside down translation being out of order

### DIFF
--- a/src/generated/resources/.cache/6dd307acdcaf85ca0b575df3e45c623e9cdab759
+++ b/src/generated/resources/.cache/6dd307acdcaf85ca0b575df3e45c623e9cdab759
@@ -1,12 +1,12 @@
-// 1.21.8	2025-07-20T09:09:50.09422877	Registrate Provider for testmod [Registries, Data Maps, , Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Model Definitions - testmod, Lang (en_us/en_ud), generic_client_provider]
+// 1.21.8	2025-10-26T21:27:27.2231794	Registrate Provider for testmod [Registries, Data Maps, , Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Model Definitions - testmod, Lang (en_us/en_ud), generic_client_provider]
 353e0134b90278ff49840165bed05cb48e7fff1b assets/testmod/blockstates/magic_item_model.json
 bc6ecd9ef8452b21567c005ab9c626c54a1beeaa assets/testmod/blockstates/testblock.json
 069fa0cc9495cbad97a129b3e39bd0bdf0599b28 assets/testmod/blockstates/testfluid.json
 f89300065873b3d7b9ce32afdc50aa054bf394c9 assets/testmod/items/magic_item_model.json
 9a69e68a4d502233127cbf455882bfccf73db0f7 assets/testmod/items/testblock.json
 1e6a2105bb914bd0e1433b408fde3c456245968a assets/testmod/items/testitem.json
-5499519c3582b4dd1d88f0b713926b60d52ffed0 assets/testmod/lang/en_ud.json
-ecccfddb2cc9cdf08dbfbc93f0c9bbe2440d1fa9 assets/testmod/lang/en_us.json
+768a14df7851185a11ea4198df6ef553dfc59c1d assets/testmod/lang/en_ud.json
+3de215df116ebdca8011aaee94098a92fed18cab assets/testmod/lang/en_us.json
 b3c7ac87f735c9813d09ee46f1d26c844c06353c assets/testmod/models/block/subfolder/magic_item_model.json
 226ecfcb53fb775aa96f550dcc41bc44c026127f assets/testmod/models/block/testblock.json
 6cde7304ac9429b0ea7e01078b4846b1cac6a0c8 data/minecraft/tags/block/bamboo_plantable_on.json

--- a/src/generated/resources/assets/testmod/lang/en_ud.json
+++ b/src/generated/resources/assets/testmod/lang/en_ud.json
@@ -11,5 +11,7 @@
   "item.testmod.testitem.testextra": "¡ɔıbɐW",
   "itemGroup.testmod.test_creative_mode_tab": "qɐ⟘ ǝpoW ǝʌıʇɐǝɹƆ ʇsǝ⟘",
   "testmod.custom.lang": "ʇsǝ⟘",
+  "testmod.custom.lang.with_placeholders1": "%2$s ᄅ ɹǝpןoɥǝɔɐןԀ %1$s Ɩ ɹǝpןoɥǝɔɐןԀ",
+  "testmod.custom.lang.with_placeholders2": "%3$s Ɛ ɹǝpןoɥǝɔɐןԀ %2$s ᄅ ɹǝpןoɥǝɔɐןԀ %1$s Ɩ ɹǝpןoɥǝɔɐןԀ",
   "tooltip.testmod.testblock": "˙bbƎ"
 }

--- a/src/generated/resources/assets/testmod/lang/en_us.json
+++ b/src/generated/resources/assets/testmod/lang/en_us.json
@@ -11,5 +11,7 @@
   "item.testmod.testitem.testextra": "Magic!",
   "itemGroup.testmod.test_creative_mode_tab": "Test Creative Mode Tab",
   "testmod.custom.lang": "Test",
+  "testmod.custom.lang.with_placeholders1": "Placeholder 1 %s Placeholder 2 %s",
+  "testmod.custom.lang.with_placeholders2": "Placeholder 1 %s Placeholder 2 %2$s Placeholder 3 %s",
   "tooltip.testmod.testblock": "Egg."
 }

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
@@ -20,6 +20,7 @@ import net.neoforged.neoforge.common.data.LanguageProvider;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -145,19 +146,29 @@ public class RegistrateLangProvider extends LanguageProvider implements Registra
     }
 
     private String toUpsideDown(String normal) {
-        char[] ud = new char[normal.length()];
+        int formatIndex = 1;
+        ArrayList<Character> ud = new ArrayList<>();
         for (int i = 0; i < normal.length(); i++) {
             char c = normal.charAt(i);
             if (c == '%') {
                 String fmtArg = "";
                 while (Character.isDigit(c) || c == '%' || c == '$' || c == 's' || c == 'd') { // TODO this is a bit lazy
+                    if (fmtArg.equals("%") && c == 's') {
+                        fmtArg = "%" + formatIndex + "$s";
+                        formatIndex++;
+                        i++;
+                        break;
+                    }
+                    else if (c == '$') {
+                        formatIndex++;
+                    }
                     fmtArg += c;
                     i++;
                     c = i == normal.length() ? 0 : normal.charAt(i);
                 }
                 i--;
-                for (int j = 0; j < fmtArg.length(); j++) {
-                    ud[normal.length() - 1 - i + j] = fmtArg.charAt(j);
+                for (int j = fmtArg.length() - 1; j >= 0; j--) {
+                    ud.addFirst(fmtArg.charAt(j));
                 }
                 continue;
             }
@@ -165,9 +176,13 @@ public class RegistrateLangProvider extends LanguageProvider implements Registra
             if (lookup >= 0) {
                 c = UPSIDE_DOWN_CHARS.charAt(lookup);
             }
-            ud[normal.length() - 1 - i] = c;
+            ud.addFirst(c);
         }
-        return new String(ud);
+        StringBuilder builder = new StringBuilder(ud.size());
+        for (Character ch : ud) {
+            builder.append(ch);
+        }
+        return builder.toString();
     }
 
     @Override

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -337,6 +337,8 @@ public class TestMod {
     public TestMod(IEventBus eventBus) {
 
         registrate.addRawLang("testmod.custom.lang", "Test");
+        registrate.addRawLang("testmod.custom.lang.with_placeholders1", "Placeholder 1 %s Placeholder 2 %s");
+        registrate.addRawLang("testmod.custom.lang.with_placeholders2", "Placeholder 1 %s Placeholder 2 %2$s Placeholder 3 %s");
         registrate.addLang("tooltip", testblock.getId(), "Egg.");
         registrate.addLang("item", testitem.getId(), "testextra", "Magic!");
         registrate.addDataGenerator(ProviderType.ADVANCEMENT, adv -> {


### PR DESCRIPTION
Registrate does not reorder placeholders in translation strings when generating upside down translations. This means that a translation like `Placeholder 1 %s Placeholder 2 %s` would translate to `Placeholder 1 one Placeholder 2 two` in English, but `one ᄅ ɹǝpןoɥǝɔɐןԀ two Ɩ ɹǝpןoɥǝɔɐןԀ` in upside down English. This PR fixes that, so the upside down translation becomes `two ᄅ ɹǝpןoɥǝɔɐןԀ one Ɩ ɹǝpןoɥǝɔɐןԀ` with the placeholders ordered accordingly.

The test strings added here would have been generated as follows without this fix:
```
  "testmod.custom.lang.with_placeholders1": "%s ᄅ ɹǝpןoɥǝɔɐןԀ %s Ɩ ɹǝpןoɥǝɔɐןԀ",
  "testmod.custom.lang.with_placeholders2": "%s Ɛ ɹǝpןoɥǝɔɐןԀ %2$s ᄅ ɹǝpןoɥǝɔɐןԀ %s Ɩ ɹǝpןoɥǝɔɐןԀ",
```