### PR TITLE
Update gradle.properties to force test class auto inclusion again

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,4 @@ neo_version=21.1.228
 
 neogradle.subsystems.parchment.minecraftVersion=1.21.1
 neogradle.subsystems.parchment.mappingsVersion=2024.11.17
+neogradle.subsystems.conventions.sourcesets.automatic-inclusion-test=true


### PR DESCRIPTION
Makes the test source behavior like how it was prior to [this PR](https://github.com/neoforged/NeoGradle/pull/232)