### PR TITLE
Add self types to block, blockentity, entity, fluid and item builders for easier extensibility

### DIFF
--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -960,205 +960,206 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     // Items
 
-    public <T extends Item> ItemBuilder<T, S> item(NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, B extends ItemBuilder<T, S, B>> B item(NonNullFunction<Item.Properties, T> factory) {
         return item(self(), factory);
     }
 
-    public <T extends Item> ItemBuilder<T, S> item(String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, B extends ItemBuilder<T, S, B>> B item(String name, NonNullFunction<Item.Properties, T> factory) {
         return item(self(), name, factory);
     }
 
-    public <T extends Item, P> ItemBuilder<T, P> item(P parent, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P, B extends ItemBuilder<T, P, B>> B item(P parent, NonNullFunction<Item.Properties, T> factory) {
         return item(parent, currentName(), factory);
     }
 
-    public <T extends Item, P> ItemBuilder<T, P> item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
-        return entry(name, callback -> ItemBuilder.create(this, parent, name, callback, factory)
+    @SuppressWarnings("unchecked")
+    public <T extends Item, P, B extends ItemBuilder<T, P, B>> B item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
+        return (B) entry(name, callback -> ItemBuilder.create(this, parent, name, callback, factory)
                 .transform(builder -> this.defaultCreativeModeTab == null ? builder : builder.tab(this.defaultCreativeModeTab)));
     }
 
     // Blocks
 
-    public <T extends Block> BlockBuilder<T, S> block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, B extends BlockBuilder<T, S, B>> B block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), factory);
     }
 
-    public <T extends Block> BlockBuilder<T, S> block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, B extends BlockBuilder<T, S, B>> B block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), name, factory);
     }
 
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P, B extends BlockBuilder<T, P, B>> B block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(parent, currentName(), factory);
     }
 
-    public <T extends Block, P> BlockBuilder<T, P> block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P, B extends BlockBuilder<T, P, B>> B block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return entry(name, callback -> BlockBuilder.create(this, parent, name, callback, factory));
     }
 
     // Entities
 
-    public <T extends Entity> EntityBuilder<T, S> entity(EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, B extends EntityBuilder<T, S, B>> B entity(EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), factory, classification);
     }
 
-    public <T extends Entity> EntityBuilder<T, S> entity(String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, B extends EntityBuilder<T, S, B>> B entity(String name, EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), name, factory, classification);
     }
 
-    public <T extends Entity, P> EntityBuilder<T, P> entity(P parent, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P, B extends EntityBuilder<T, P, B>> B entity(P parent, EntityFactory<T> factory, MobCategory classification) {
         return entity(parent, currentName(), factory, classification);
     }
 
-    public <T extends Entity, P> EntityBuilder<T, P> entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P, B extends EntityBuilder<T, P, B>> B entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
         return entry(name, callback -> EntityBuilder.create(this, parent, name, callback, factory, classification));
     }
 
     // Block Entities
 
-    public <T extends BlockEntity> BlockEntityBuilder<T, S> blockEntity(BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, B extends BlockEntityBuilder<T, S, B>> B blockEntity(BlockEntityFactory<T> factory) {
         return blockEntity(self(), factory);
     }
 
-    public <T extends BlockEntity> BlockEntityBuilder<T, S> blockEntity(String name, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, B extends BlockEntityBuilder<T, S, B>> B blockEntity(String name, BlockEntityFactory<T> factory) {
         return blockEntity(self(), name, factory);
     }
 
-    public <T extends BlockEntity, P> BlockEntityBuilder<T, P> blockEntity(P parent, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, P, B extends BlockEntityBuilder<T, P, B>> B blockEntity(P parent, BlockEntityFactory<T> factory) {
         return blockEntity(parent, currentName(), factory);
     }
 
-    public <T extends BlockEntity, P> BlockEntityBuilder<T, P> blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, P, B extends BlockEntityBuilder<T, P, B>> B blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
         return entry(name, callback -> BlockEntityBuilder.create(this, parent, name, callback, factory));
     }
 
     // Fluids
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid() {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid() {
         return fluid(self());
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(FluidBuilder.FluidTypeFactory typeFactory) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), typeFactory);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(NonNullSupplier<FluidType> fluidType) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), fluidType);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(Identifier stillTexture, Identifier flowingTexture) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture) {
         return fluid(self(), stillTexture, flowingTexture);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
                                                                  FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name) {
         return fluid(self(), name);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, typeFactory);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name, NonNullSupplier<FluidType> fluidType) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, fluidType);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture) {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, typeFactory);
     }
 
-    public FluidBuilder<BaseFlowingFluid.Flowing, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
                                                                  FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid> FluidBuilder<T, S> fluid(String name, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent) {
         return fluid(parent, currentName());
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), typeFactory);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, NonNullSupplier<FluidType> fluidType) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), fluidType);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture) {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
                                                                     FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture());
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture(), typeFactory);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture(), fluidType);
     }
 
@@ -1170,31 +1171,34 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return Identifier.fromNamespaceAndPath(getModid(), "block/" + currentName() + "_flow");
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, FluidType::new)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, FluidType::new)).model(stillTexture, flowingTexture);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, typeFactory)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, typeFactory)).model(stillTexture, flowingTexture);
     }
 
-    public <P> FluidBuilder<BaseFlowingFluid.Flowing, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, fluidType)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidType)).model(stillTexture, flowingTexture);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture,
-                                                                    FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, fluidFactory)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture,
-        FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, typeFactory, fluidFactory)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, typeFactory, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
-    public <T extends BaseFlowingFluid, P> FluidBuilder<T, P> fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture,
-        NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> FluidBuilder.create(this, parent, name, callback, fluidType, fluidFactory)).model(stillTexture, flowingTexture);
+    @SuppressWarnings("unchecked")
+    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidType, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
     // Menu

--- a/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
+++ b/src/main/java/com/tterrag/registrate/AbstractRegistrate.java
@@ -960,206 +960,204 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
 
     // Items
 
-    public <T extends Item, B extends ItemBuilder<T, S, B>> B item(NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, IB extends ItemBuilder<T, S, IB>> IB item(NonNullFunction<Item.Properties, T> factory) {
         return item(self(), factory);
     }
 
-    public <T extends Item, B extends ItemBuilder<T, S, B>> B item(String name, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, IB extends ItemBuilder<T, S, IB>> IB item(String name, NonNullFunction<Item.Properties, T> factory) {
         return item(self(), name, factory);
     }
 
-    public <T extends Item, P, B extends ItemBuilder<T, P, B>> B item(P parent, NonNullFunction<Item.Properties, T> factory) {
+    public <T extends Item, P, IB extends ItemBuilder<T, P, IB>> IB item(P parent, NonNullFunction<Item.Properties, T> factory) {
         return item(parent, currentName(), factory);
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends Item, P, B extends ItemBuilder<T, P, B>> B item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
-        return (B) entry(name, callback -> ItemBuilder.create(this, parent, name, callback, factory)
+    public <T extends Item, P, IB extends ItemBuilder<T, P, IB>> IB item(P parent, String name, NonNullFunction<Item.Properties, T> factory) {
+        return entry(name, callback -> ItemBuilder.<T, P, IB>create(this, parent, name, callback, factory)
                 .transform(builder -> this.defaultCreativeModeTab == null ? builder : builder.tab(this.defaultCreativeModeTab)));
     }
 
     // Blocks
 
-    public <T extends Block, B extends BlockBuilder<T, S, B>> B block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, BB extends BlockBuilder<T, S, BB>> BB block(NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), factory);
     }
 
-    public <T extends Block, B extends BlockBuilder<T, S, B>> B block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, BB extends BlockBuilder<T, S, BB>> BB block(String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(self(), name, factory);
     }
 
-    public <T extends Block, P, B extends BlockBuilder<T, P, B>> B block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P, BB extends BlockBuilder<T, P, BB>> BB block(P parent, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return block(parent, currentName(), factory);
     }
 
-    public <T extends Block, P, B extends BlockBuilder<T, P, B>> B block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+    public <T extends Block, P, BB extends BlockBuilder<T, P, BB>> BB block(P parent, String name, NonNullFunction<BlockBehaviour.Properties, T> factory) {
         return entry(name, callback -> BlockBuilder.create(this, parent, name, callback, factory));
     }
 
     // Entities
 
-    public <T extends Entity, B extends EntityBuilder<T, S, B>> B entity(EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, EB extends EntityBuilder<T, S, EB>> EB entity(EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), factory, classification);
     }
 
-    public <T extends Entity, B extends EntityBuilder<T, S, B>> B entity(String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, EB extends EntityBuilder<T, S, EB>> EB entity(String name, EntityFactory<T> factory, MobCategory classification) {
         return entity(self(), name, factory, classification);
     }
 
-    public <T extends Entity, P, B extends EntityBuilder<T, P, B>> B entity(P parent, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P, EB extends EntityBuilder<T, P, EB>> EB entity(P parent, EntityFactory<T> factory, MobCategory classification) {
         return entity(parent, currentName(), factory, classification);
     }
 
-    public <T extends Entity, P, B extends EntityBuilder<T, P, B>> B entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
+    public <T extends Entity, P, EB extends EntityBuilder<T, P, EB>> EB entity(P parent, String name, EntityFactory<T> factory, MobCategory classification) {
         return entry(name, callback -> EntityBuilder.create(this, parent, name, callback, factory, classification));
     }
 
     // Block Entities
 
-    public <T extends BlockEntity, B extends BlockEntityBuilder<T, S, B>> B blockEntity(BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, BEB extends BlockEntityBuilder<T, S, BEB>> BEB blockEntity(BlockEntityFactory<T> factory) {
         return blockEntity(self(), factory);
     }
 
-    public <T extends BlockEntity, B extends BlockEntityBuilder<T, S, B>> B blockEntity(String name, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, BEB extends BlockEntityBuilder<T, S, BEB>> BEB blockEntity(String name, BlockEntityFactory<T> factory) {
         return blockEntity(self(), name, factory);
     }
 
-    public <T extends BlockEntity, P, B extends BlockEntityBuilder<T, P, B>> B blockEntity(P parent, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, P, BEB extends BlockEntityBuilder<T, P, BEB>> BEB blockEntity(P parent, BlockEntityFactory<T> factory) {
         return blockEntity(parent, currentName(), factory);
     }
 
-    public <T extends BlockEntity, P, B extends BlockEntityBuilder<T, P, B>> B blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
+    public <T extends BlockEntity, P, BEB extends BlockEntityBuilder<T, P, BEB>> BEB blockEntity(P parent, String name, BlockEntityFactory<T> factory) {
         return entry(name, callback -> BlockEntityBuilder.create(this, parent, name, callback, factory));
     }
 
     // Fluids
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid() {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid() {
         return fluid(self());
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(FluidBuilder.FluidTypeFactory typeFactory) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), typeFactory);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(NonNullSupplier<FluidType> fluidType) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), fluidType);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture) {
         return fluid(self(), stillTexture, flowingTexture);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture,
                                                                  FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name) {
         return fluid(self(), name);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, typeFactory);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, NonNullSupplier<FluidType> fluidType) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, fluidType);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture) {
         return fluid(self(), name, stillTexture, flowingTexture);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, typeFactory);
     }
 
-    public <B extends FluidBuilder<BaseFlowingFluid.Flowing, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <FB extends FluidBuilder<BaseFlowingFluid.Flowing, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
-                                                                 FluidBuilder.FluidFactory<T> fluidFactory) {
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, B extends FluidBuilder<T, S, B>> B fluid(String name, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, FB extends FluidBuilder<T, S, FB>> FB fluid(String name, Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(self(), name, stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent) {
         return fluid(parent, currentName());
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), typeFactory);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, NonNullSupplier<FluidType> fluidType) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), fluidType);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture) {
         return fluid(parent, currentName(), stillTexture, flowingTexture);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType);
     }
 
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
                                                                     FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
         FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, typeFactory, fluidFactory);
     }
 
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, Identifier stillTexture, Identifier flowingTexture,
         NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
         return fluid(parent, currentName(), stillTexture, flowingTexture, fluidType, fluidFactory);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture());
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name, FluidBuilder.FluidTypeFactory typeFactory) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture(), typeFactory);
     }
 
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name, NonNullSupplier<FluidType> fluidType) {
         return fluid(parent, name, defaultStillTexture(), defaultFlowingTexture(), fluidType);
     }
 
@@ -1171,34 +1169,28 @@ public abstract class AbstractRegistrate<S extends AbstractRegistrate<S>> {
         return Identifier.fromNamespaceAndPath(getModid(), "block/" + currentName() + "_flow");
     }
 
-    @SuppressWarnings("unchecked")
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, FluidType::new)).model(stillTexture, flowingTexture);
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture) {
+        return entry(name, callback -> FluidBuilder.<P, FB>create(this, parent, name, callback, FluidType::new)).model(stillTexture, flowingTexture);
     }
 
-    @SuppressWarnings("unchecked")
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, typeFactory)).model(stillTexture, flowingTexture);
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory) {
+        return entry(name, callback -> FluidBuilder.<P, FB>create(this, parent, name, callback, typeFactory)).model(stillTexture, flowingTexture);
     }
 
-    @SuppressWarnings("unchecked")
-    public <P, B extends FluidBuilder<BaseFlowingFluid.Flowing, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidType)).model(stillTexture, flowingTexture);
+    public <P, FB extends FluidBuilder<BaseFlowingFluid.Flowing, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType) {
+        return entry(name, callback -> FluidBuilder.<P, FB>create(this, parent, name, callback, fluidType)).model(stillTexture, flowingTexture);
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidFactory)).model(stillTexture, flowingTexture);
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.<T, P, FB>create(this, parent, name, callback, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, typeFactory, fluidFactory)).model(stillTexture, flowingTexture);
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, FluidBuilder.FluidTypeFactory typeFactory, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.<T, P, FB>create(this, parent, name, callback, typeFactory, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends BaseFlowingFluid, P, B extends FluidBuilder<T, P, B>> B fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
-        return entry(name, callback -> (B) FluidBuilder.create(this, parent, name, callback, fluidType, fluidFactory)).model(stillTexture, flowingTexture);
+    public <T extends BaseFlowingFluid, P, FB extends FluidBuilder<T, P, FB>> FB fluid(P parent, String name, Identifier stillTexture, Identifier flowingTexture, NonNullSupplier<FluidType> fluidType, FluidBuilder.FluidFactory<T> fluidFactory) {
+        return entry(name, callback -> FluidBuilder.<T, P, FB>create(this, parent, name, callback, fluidType, fluidFactory)).model(stillTexture, flowingTexture);
     }
 
     // Menu

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
+
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
 import org.jspecify.annotations.Nullable;
 
 import com.tterrag.registrate.AbstractRegistrate;
@@ -88,8 +90,7 @@ public class BlockBuilder<T extends Block, P, S extends BlockBuilder<T, P, S>> e
      * @return A new {@link BlockBuilder} with reasonable default data generators.
      */
     public static <T extends Block, P, S extends BlockBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<BlockBehaviour.Properties, T> factory) {
-        return new BlockBuilder<T, P, S>(owner, parent, name, callback, factory, BlockBehaviour.Properties::of)
-                .defaultBlockstate().defaultLoot().defaultLang();
+        return new BlockBuilder<T, P, S>(owner, parent, name, callback, factory, BlockBehaviour.Properties::of).defaultBlockstate().defaultLoot().defaultLang();
     }
 
     private final NonNullFunction<BlockBehaviour.Properties, T> factory;
@@ -177,7 +178,7 @@ public class BlockBuilder<T extends Block, P, S extends BlockBuilder<T, P, S>> e
                 .model(() -> (ctx, prov) -> {
                     getOwner().getDataProvider(ProviderType.BLOCKSTATE)
                             .map(g -> g.seenBlockstates.get(getEntry()))
-                            .flatMap(b -> b.simpleModels())
+                            .flatMap(BlockStateModelDispatcher::simpleModels)
                             .map(b -> b.models().get(""))
                             .map(unbaked -> {
                                 if (unbaked instanceof SingleVariant.Unbaked(Variant variant)) {
@@ -213,9 +214,8 @@ public class BlockBuilder<T extends Block, P, S extends BlockBuilder<T, P, S>> e
      *            A factory for the block entity
      * @return the {@link BlockEntityBuilder}
      */
-    @SuppressWarnings("unchecked")
-    public <BE extends BlockEntity, B extends BlockEntityBuilder<BE, S, B>> B blockEntity(BlockEntityFactory<BE> factory) {
-        return (B) getOwner().blockEntity(self(), getName(), factory).validBlock(asSupplier());
+    public <BE extends BlockEntity, BEB extends BlockEntityBuilder<BE, S, BEB>> BEB blockEntity(BlockEntityFactory<BE> factory) {
+        return getOwner().<BE, S, BEB>blockEntity(self(), getName(), factory).validBlock(asSupplier());
     }
     
     /**

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -53,8 +53,10 @@ import net.neoforged.neoforge.registries.DeferredHolder;
  *            The type of block being built
  * @param <P>
  *            Parent object type
+ * @param <S>
+ *            Self type
  */
-public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, P, BlockBuilder<T, P>> {
+public class BlockBuilder<T extends Block, P, S extends BlockBuilder<T, P, S>> extends AbstractBuilder<Block, T, P, S> {
 
     /**
      * Create a new {@link BlockBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
@@ -71,6 +73,8 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -83,8 +87,8 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            Factory to create the block
      * @return A new {@link BlockBuilder} with reasonable default data generators.
      */
-    public static <T extends Block, P> BlockBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<BlockBehaviour.Properties, T> factory) {
-        return new BlockBuilder<>(owner, parent, name, callback, factory, () -> BlockBehaviour.Properties.of())
+    public static <T extends Block, P, S extends BlockBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<BlockBehaviour.Properties, T> factory) {
+        return new BlockBuilder<T, P, S>(owner, parent, name, callback, factory, BlockBehaviour.Properties::of)
                 .defaultBlockstate().defaultLoot().defaultLang();
     }
 
@@ -101,6 +105,11 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
         this.initialProperties = initialProperties;
     }
 
+    @SuppressWarnings("unchecked")
+    protected final S self() {
+        return (S) this;
+    }
+
     /**
      * Modify the properties of the block. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
      * different operations.
@@ -111,9 +120,9 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            The action to perform on the properties
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> properties(NonNullUnaryOperator<BlockBehaviour.Properties> func) {
+    public S properties(NonNullUnaryOperator<BlockBehaviour.Properties> func) {
         propertiesCallback = propertiesCallback.andThen(func);
-        return this;
+        return self();
     }
 
     /**
@@ -123,9 +132,9 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            The block to create the initial properties from (via {@link Block.Properties#ofFullCopy(BlockBehaviour)})
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> initialProperties(NonNullSupplier<? extends Block> block) {
+    public S initialProperties(NonNullSupplier<? extends Block> block) {
         initialProperties = () -> BlockBehaviour.Properties.ofFullCopy(block.get());
-        return this;
+        return self();
     }
 
     /**
@@ -136,7 +145,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      * @see #item()
      */
-    public BlockBuilder<T, P> simpleItem() {
+    public S simpleItem() {
         return item().build();
     }
 
@@ -147,7 +156,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * 
      * @return the {@link ItemBuilder} for the {@link BlockItem}
      */
-    public ItemBuilder<BlockItem, BlockBuilder<T, P>> item() {
+    public <IB extends ItemBuilder<BlockItem, S, IB>> IB item() {
         return item(BlockItem::new);
     }
 
@@ -162,8 +171,8 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            A factory for the item, which accepts the block object and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BlockItem}
      */
-    public <I extends Item> ItemBuilder<I, BlockBuilder<T, P>> item(NonNullBiFunction<? super T, Item.Properties, ? extends I> factory) {
-        return getOwner().<I, BlockBuilder<T, P>> item(this, getName(), p -> factory.apply(getEntry(), p.useBlockDescriptionPrefix()))
+    public <I extends Item, IB extends ItemBuilder<I, S, IB>> IB item(NonNullBiFunction<? super T, Item.Properties, ? extends I> factory) {
+        return getOwner().<I, S, IB>item(self(), getName(), p -> factory.apply(getEntry(), p.useBlockDescriptionPrefix()))
                 .setData(ProviderType.LANG, NonNullBiConsumer.noop()) // FIXME Need a beetter API for "unsetting" providers
                 .model(() -> (ctx, prov) -> {
                     getOwner().getDataProvider(ProviderType.BLOCKSTATE)
@@ -189,7 +198,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            A factory for the block entity
      * @return this {@link BlockBuilder}
      */
-    public <BE extends BlockEntity> BlockBuilder<T, P> simpleBlockEntity(BlockEntityFactory<BE> factory) {
+    public <BE extends BlockEntity> S simpleBlockEntity(BlockEntityFactory<BE> factory) {
         return blockEntity(factory).build();
     }
 
@@ -204,8 +213,9 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            A factory for the block entity
      * @return the {@link BlockEntityBuilder}
      */
-    public <BE extends BlockEntity> BlockEntityBuilder<BE, BlockBuilder<T, P>> blockEntity(BlockEntityFactory<BE> factory) {
-        return getOwner().<BE, BlockBuilder<T, P>>blockEntity(this, getName(), factory).validBlock(asSupplier());
+    @SuppressWarnings("unchecked")
+    public <BE extends BlockEntity, B extends BlockEntityBuilder<BE, S, B>> B blockEntity(BlockEntityFactory<BE> factory) {
+        return (B) getOwner().blockEntity(self(), getName(), factory).validBlock(asSupplier());
     }
     
     /**
@@ -215,12 +225,12 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      */
     // TODO it might be worthwhile to abstract this more and add the capability to automatically copy to the item
-    public BlockBuilder<T, P> color(NonNullSupplier<Supplier<List<BlockTintSource>>> tintSources) {
+    public S color(NonNullSupplier<Supplier<List<BlockTintSource>>> tintSources) {
         if (this.tintSources == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerBlockColor);
         }
         this.tintSources = tintSources;
-        return this;
+        return self();
     }
     
     protected void registerBlockColor() {
@@ -238,7 +248,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * 
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> defaultBlockstate() {
+    public S defaultBlockstate() {
         return blockstate(() -> (ctx, prov) -> prov.createTrivialCube(ctx.getEntry()));
     }
 
@@ -250,8 +260,8 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      * @see #setData(GeneratorType, NonNullBiConsumer)
      */
-    public BlockBuilder<T, P> blockstate(NonNullSupplier<NonNullBiConsumer<DataGenContext<Block, T>, RegistrateBlockModelGenerator>> cons) {
-        if (!getOwner().doDatagen().get()) return this;
+    public S blockstate(NonNullSupplier<NonNullBiConsumer<DataGenContext<Block, T>, RegistrateBlockModelGenerator>> cons) {
+        if (!getOwner().doDatagen().get()) return self();
         return setData(ProviderType.BLOCKSTATE, cons.get());
     }
 
@@ -261,7 +271,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * 
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> defaultLang() {
+    public S defaultLang() {
         return lang(Block::getDescriptionId);
     }
 
@@ -272,7 +282,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            A localized English name
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> lang(String name) {
+    public S lang(String name) {
         return lang(Block::getDescriptionId, name);
     }
 
@@ -282,7 +292,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * 
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> defaultLoot() {
+    public S defaultLoot() {
         return loot(RegistrateBlockLootTables::dropSelf);
     }
 
@@ -296,7 +306,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            The callback which will be invoked during block loot table creation.
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> loot(NonNullBiConsumer<RegistrateBlockLootTables, T> cons) {
+    public S loot(NonNullBiConsumer<RegistrateBlockLootTables, T> cons) {
         return setData(ProviderType.LOOT, (ctx, prov) -> prov.addLootAction(LootType.BLOCK, tb -> {
             if (ctx.getEntry().getLootTable().isPresent()) {
                 cons.accept(tb, ctx.getEntry());
@@ -312,7 +322,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      * @see #setData(GeneratorType, NonNullBiConsumer)
      */
-    public BlockBuilder<T, P> recipe(NonNullBiConsumer<DataGenContext<Block, T>, RegistrateRecipeProvider> cons) {
+    public S recipe(NonNullBiConsumer<DataGenContext<Block, T>, RegistrateRecipeProvider> cons) {
         return setData(ProviderType.RECIPE, cons);
     }
 
@@ -326,12 +336,12 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      *            The client extension to register for this block
      * @return this {@link BlockBuilder}
      */
-    public BlockBuilder<T, P> clientExtension(NonNullSupplier<Supplier<IClientBlockExtensions>> clientExtension) {
+    public S clientExtension(NonNullSupplier<Supplier<IClientBlockExtensions>> clientExtension) {
         if (this.clientExtensionFunc == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientExtension);
         }
         this.clientExtensionFunc = block -> clientExtension;
-        return this;
+        return self();
     }
 
     /**
@@ -343,12 +353,12 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      */
     @Deprecated(forRemoval = true)
-    public BlockBuilder<T, P> clientExtension(Function<T, NonNullSupplier<Supplier<IClientBlockExtensions>>> clientExtension) {
+    public S clientExtension(Function<T, NonNullSupplier<Supplier<IClientBlockExtensions>>> clientExtension) {
         if (this.clientExtensionFunc == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientExtension);
         }
         this.clientExtensionFunc = clientExtension;
-        return this;
+        return self();
     }
 
     protected void registerClientExtension() {
@@ -368,7 +378,7 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
      * @return this {@link BlockBuilder}
      */
     @SafeVarargs
-    public final BlockBuilder<T, P> tag(TagKey<Block>... tags) {
+    public final S tag(TagKey<Block>... tags) {
         return tag(ProviderType.BLOCK_TAGS, tags);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockEntityBuilder.java
@@ -38,13 +38,13 @@ import net.neoforged.neoforge.registries.DeferredHolder;
  *            The type of block entity being built
  * @param <P>
  *            Parent object type
+ * @param <S>
+ *            Self type
  */
-public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilder<BlockEntityType<?>, BlockEntityType<T>, P, BlockEntityBuilder<T, P>> {
+public class BlockEntityBuilder<T extends BlockEntity, P, S extends BlockEntityBuilder<T, P, S>> extends AbstractBuilder<BlockEntityType<?>, BlockEntityType<T>, P, S> {
 
     public interface BlockEntityFactory<T extends BlockEntity> {
-
-        public T create(BlockEntityType<T> type, BlockPos pos, BlockState state);
-
+        T create(BlockEntityType<T> type, BlockPos pos, BlockState state);
     }
 
     /**
@@ -56,6 +56,8 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -68,8 +70,8 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            Factory to create the block entity
      * @return A new {@link BlockEntityBuilder} with reasonable default data generators.
      */
-    public static <T extends BlockEntity, P> BlockEntityBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
-        return new BlockEntityBuilder<>(owner, parent, name, callback, factory);
+    public static <T extends BlockEntity, P, S extends BlockEntityBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, BlockEntityFactory<T> factory) {
+        return new BlockEntityBuilder<T, P, S>(owner, parent, name, callback, factory).self();
     }
 
     private final BlockEntityFactory<T> factory;
@@ -80,6 +82,11 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
         super(owner, parent, name, callback, Registries.BLOCK_ENTITY_TYPE);
         this.factory = factory;
     }
+
+    @SuppressWarnings("unchecked")
+    protected final S self() {
+        return (S) this;
+    }
     
     /**
      * Add a valid block for this block entity.
@@ -88,9 +95,9 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A supplier for the block to add at registration time
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> validBlock(NonNullSupplier<? extends Block> block) {
+    public S validBlock(NonNullSupplier<? extends Block> block) {
         validBlocks.add(block);
-        return this;
+        return self();
     }
     
     /**
@@ -101,9 +108,9 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      * @return this {@link BlockEntityBuilder}
      */
     @SafeVarargs
-    public final BlockEntityBuilder<T, P> validBlocks(NonNullSupplier<? extends Block>... blocks) {
+    public final S validBlocks(NonNullSupplier<? extends Block>... blocks) {
         Arrays.stream(blocks).forEach(this::validBlock);
-        return this;
+        return self();
     }
     
     /**
@@ -116,12 +123,12 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      *            A (server safe) supplier to an {@link Function} that will provide this block entity's renderer given the renderer dispatcher
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T, ?>>> renderer) {
+    public S renderer(NonNullSupplier<NonNullFunction<BlockEntityRendererProvider.Context, BlockEntityRenderer<? super T, ?>>> renderer) {
         if (this.renderer == null) { // First call only
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerRenderer);
         }
         this.renderer = renderer;
-        return this;
+        return self();
     }
     
     protected void registerRenderer() {
@@ -139,9 +146,9 @@ public class BlockEntityBuilder<T extends BlockEntity, P> extends AbstractBuilde
      * @param registerCapabilitiesEvent A consumer for the register capabilities event
      * @return this {@link BlockEntityBuilder}
      */
-    public BlockEntityBuilder<T, P> registerCapability(Consumer<RegisterCapabilitiesEvent> registerCapabilitiesEvent) {
+    public S registerCapability(Consumer<RegisterCapabilitiesEvent> registerCapabilitiesEvent) {
         OneTimeEventReceiver.addModListener(getOwner(), RegisterCapabilitiesEvent.class, registerCapabilitiesEvent);
-        return this;
+        return self();
     }
 
     @Override

--- a/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/EntityBuilder.java
@@ -42,8 +42,10 @@ import java.util.function.Supplier;
  *            The type of entity being built
  * @param <P>
  *            Parent object type
+ * @param <S>
+ *            Self type
  */
-public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityType<?>, EntityType<T>, P, EntityBuilder<T, P>> {
+public class EntityBuilder<T extends Entity, P, S extends EntityBuilder<T, P, S>> extends AbstractBuilder<EntityType<?>, EntityType<T>, P, S> {
 
     /**
      * Create a new {@link EntityBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
@@ -57,6 +59,8 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -71,10 +75,8 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            The {@link MobCategory} of the entity
      * @return A new {@link EntityBuilder} with reasonable default data generators.
      */
-    public static <T extends Entity, P> EntityBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EntityType.EntityFactory<T> factory,
-            MobCategory classification) {
-        return new EntityBuilder<>(owner, parent, name, callback, factory, classification)
-                .defaultLang();
+    public static <T extends Entity, P, S extends EntityBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, EntityType.EntityFactory<T> factory, MobCategory classification) {
+        return new EntityBuilder<T, P, S>(owner, parent, name, callback, factory, classification).defaultLang();
     }
 
     private final NonNullSupplier<EntityType.Builder<T>> builder;
@@ -90,6 +92,11 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
         this.builder = () -> EntityType.Builder.of(factory, classification);
     }
 
+    @SuppressWarnings("unchecked")
+    protected final S self() {
+        return (S) this;
+    }
+
     /**
      * Modify the properties of the entity. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
      * different operations.
@@ -98,9 +105,9 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            The action to perform on the properties
      * @return this {@link EntityBuilder}
      */
-    public EntityBuilder<T, P> properties(NonNullConsumer<EntityType.Builder<T>> cons) {
+    public S properties(NonNullConsumer<EntityType.Builder<T>> cons) {
         builderCallback = builderCallback.andThen(cons);
-        return this;
+        return self();
     }
 
     /**
@@ -111,12 +118,12 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            A (server safe) supplier to an {@link EntityRendererProvider} that will provide this entity's renderer
      * @return this {@link EntityBuilder}
      */
-    public EntityBuilder<T, P> renderer(NonNullSupplier<NonNullFunction<EntityRendererProvider.Context, EntityRenderer<? super T, ?>>> renderer) {
+    public S renderer(NonNullSupplier<NonNullFunction<EntityRendererProvider.Context, EntityRenderer<? super T, ?>>> renderer) {
         if (this.renderer == null && FMLEnvironment.getDist().isClient()) { // First call only
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerRenderer);
         }
         this.renderer = renderer;
-        return this;
+        return self();
     }
 
     protected void registerRenderer() {
@@ -145,13 +152,13 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *             When called more than once
      */
     @SuppressWarnings("unchecked")
-    public EntityBuilder<T, P> attributes(Supplier<AttributeSupplier.Builder> attributes) {
+    public S attributes(Supplier<AttributeSupplier.Builder> attributes) {
         if (attributesConfigured) {
             throw new IllegalStateException("Cannot configure attributes more than once");
         }
         attributesConfigured = true;
         OneTimeEventReceiver.addModListener(getOwner(), EntityAttributeCreationEvent.class, e -> e.put((EntityType<LivingEntity>) getEntry(), attributes.get().build()));
-        return this;
+        return self();
     }
 
     /**
@@ -169,8 +176,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      * @throws IllegalStateException
      *             When called more than once
      */
-    @SuppressWarnings("unchecked")
-    public EntityBuilder<T, P> spawnPlacement(SpawnPlacementType type, Heightmap.Types heightmap, SpawnPredicate<T> predicate, RegisterSpawnPlacementsEvent.Operation operation) {
+    public S spawnPlacement(SpawnPlacementType type, Heightmap.Types heightmap, SpawnPredicate<T> predicate, RegisterSpawnPlacementsEvent.Operation operation) {
         if (spawnConfigured) {
             throw new IllegalStateException("Cannot configure spawn placement more than once");
         }
@@ -189,7 +195,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
                 e.register(t, type, heightmap, predicate, operation);
             });
         });
-        return this;
+        return self();
     }
 
     /**
@@ -242,7 +248,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *
      * @return this {@link EntityBuilder}
      */
-    public EntityBuilder<T, P> defaultLang() {
+    public S defaultLang() {
         return lang(EntityType::getDescriptionId);
     }
 
@@ -253,7 +259,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            A localized English name
      * @return this {@link EntityBuilder}
      */
-    public EntityBuilder<T, P> lang(String name) {
+    public S lang(String name) {
         return lang(EntityType::getDescriptionId, name);
     }
 
@@ -265,7 +271,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      *            The callback which will be invoked during entity loot table creation.
      * @return this {@link EntityBuilder}
      */
-    public EntityBuilder<T, P> loot(NonNullBiConsumer<RegistrateEntityLootTables, EntityType<T>> cons) {
+    public S loot(NonNullBiConsumer<RegistrateEntityLootTables, EntityType<T>> cons) {
         return setData(ProviderType.LOOT, (ctx, prov) -> prov.addLootAction(LootType.ENTITY, tb -> cons.accept(tb, ctx.getEntry())));
     }
 
@@ -277,7 +283,7 @@ public class EntityBuilder<T extends Entity, P> extends AbstractBuilder<EntityTy
      * @return this {@link EntityBuilder}
      */
     @SafeVarargs
-    public final EntityBuilder<T, P> tag(TagKey<EntityType<?>>... tags) {
+    public final S tag(TagKey<EntityType<?>>... tags) {
         return tag(ProviderType.ENTITY_TAGS, tags);
     }
 

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
-public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder<Fluid, T, P, FluidBuilder<T, P>> {
+public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<T, P, S>> extends AbstractBuilder<Fluid, T, P, S> {
 
     @FunctionalInterface
     public interface FluidTypeFactory {
@@ -70,24 +70,24 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The client extension to register for this block
      * @return this {@link BlockBuilder}
      */
-    public FluidBuilder<T, P> clientExtension(NonNullSupplier<Supplier<IClientFluidTypeExtensions>> clientExtension) {
+    public S clientExtension(NonNullSupplier<Supplier<IClientFluidTypeExtensions>> clientExtension) {
         if (this.clientExtension == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientExtension);
         }
         this.clientExtension = clientExtension;
-        return this;
+        return self();
     }
 
-    public FluidBuilder<T, P> model(Identifier stillTexture, Identifier flowingTexture) {
+    public S model(Identifier stillTexture, Identifier flowingTexture) {
         return model(() -> () -> new FluidModel.Unbaked(new Material(stillTexture), new Material(flowingTexture), null, null));
     }
 
-    public FluidBuilder<T, P> model(NonNullSupplier<Supplier<FluidModel.Unbaked>> model) {
+    public S model(NonNullSupplier<Supplier<FluidModel.Unbaked>> model) {
         if (this.model == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerModel);
         }
         this.model = model;
-        return this;
+        return self();
     }
 
     protected void registerModel() {
@@ -113,6 +113,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -124,7 +126,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, FluidTypeFactory, FluidFactory)
      */
-    public static <P> FluidBuilder<BaseFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback) {
+    public static <P, S extends FluidBuilder<BaseFlowingFluid.Flowing, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback) {
         return create(owner, parent, name, callback, FluidType::new, BaseFlowingFluid.Flowing::new);
     }
 
@@ -133,6 +135,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -146,7 +150,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, FluidTypeFactory, FluidFactory)
      */
-    public static <P> FluidBuilder<BaseFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, FluidTypeFactory typeFactory) {
+    public static <P, S extends FluidBuilder<BaseFlowingFluid.Flowing, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, FluidTypeFactory typeFactory) {
         return create(owner, parent, name, callback, typeFactory, BaseFlowingFluid.Flowing::new);
     }
 
@@ -155,6 +159,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -168,7 +174,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      * @see #create(AbstractRegistrate, Object, String, BuilderCallback, FluidTypeFactory, FluidFactory)
      */
-    public static <P> FluidBuilder<BaseFlowingFluid.Flowing, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullSupplier<FluidType> fluidType) {
+    public static <P, S extends FluidBuilder<BaseFlowingFluid.Flowing, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullSupplier<FluidType> fluidType) {
         return create(owner, parent, name, callback, p -> fluidType.get(), BaseFlowingFluid.Flowing::new);
     }
 
@@ -179,6 +185,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -191,8 +199,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends BaseFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback,
-        FluidFactory<T> fluidFactory) {
+    public static <T extends BaseFlowingFluid, P, S extends FluidBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, FluidFactory<T> fluidFactory) {
         return create(owner, parent, name, callback, FluidType::new, fluidFactory);
     }
 
@@ -211,6 +218,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -225,11 +234,9 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends BaseFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback,
-        FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
-        FluidBuilder<T, P> ret = new FluidBuilder<>(owner, parent, name, callback, typeFactory, fluidFactory)
+    public static <T extends BaseFlowingFluid, P, S extends FluidBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
+        return new FluidBuilder<T, P, S>(owner, parent, name, callback, typeFactory, fluidFactory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket();
-        return ret;
     }
 
     /**
@@ -247,6 +254,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -261,9 +270,8 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory that creates the flowing fluid
      * @return A new {@link FluidBuilder} with reasonable default data generators.
      */
-    public static <T extends BaseFlowingFluid, P> FluidBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback,
-        NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
-        return new FluidBuilder<>(owner, parent, name, callback, fluidType, fluidFactory)
+    public static <T extends BaseFlowingFluid, P, S extends FluidBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullSupplier<FluidType> fluidType, FluidFactory<T> fluidFactory) {
+        return new FluidBuilder<T, P, S>(owner, parent, name, callback, fluidType, fluidFactory)
                 .defaultLang().defaultSource().defaultBlock().defaultBucket();
     }
 
@@ -302,6 +310,11 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
         this.registerType = false; // Don't register if we have a fluid from outside.
     }
 
+    @SuppressWarnings("unchecked")
+    protected final S self() {
+        return (S) this;
+    }
+
     /**
      * Modify the properties of the fluid type. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
      * different operations.
@@ -310,9 +323,9 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> properties(NonNullConsumer<FluidType.Properties> cons) {
+    public S properties(NonNullConsumer<FluidType.Properties> cons) {
         typeProperties = typeProperties.andThen(cons);
-        return this;
+        return self();
     }
 
     /**
@@ -323,9 +336,9 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            The action to perform on the attributes
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> fluidProperties(NonNullConsumer<BaseFlowingFluid.Properties> cons) {
+    public S fluidProperties(NonNullConsumer<BaseFlowingFluid.Properties> cons) {
         fluidProperties = fluidProperties.andThen(cons);
-        return this;
+        return self();
     }
 
     /**
@@ -334,7 +347,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> defaultLang() {
+    public S defaultLang() {
         return lang(f -> f.getFluidType().getDescriptionId(), RegistrateLangProvider.toEnglishName(sourceName));
     }
 
@@ -345,7 +358,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A localized English name
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> lang(String name) {
+    public S lang(String name) {
         return lang(f -> f.getFluidType().getDescriptionId(), name);
     }
 
@@ -357,12 +370,12 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @throws IllegalStateException
      *             If {@link #source(NonNullFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultSource() {
+    public S defaultSource() {
         if (this.defaultSource != null) {
             throw new IllegalStateException("Cannot set a default source after a custom source has been created");
         }
         this.defaultSource = true;
-        return this;
+        return self();
     }
 
     /**
@@ -372,10 +385,10 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory for the fluid, which accepts the properties and returns a new fluid
      * @return this {@link FluidBuilder}
      */
-    public FluidBuilder<T, P> source(NonNullFunction<BaseFlowingFluid.Properties, ? extends BaseFlowingFluid> factory) {
+    public S source(NonNullFunction<BaseFlowingFluid.Properties, ? extends BaseFlowingFluid> factory) {
         this.defaultSource = false;
         this.source = NonNullSupplier.lazy(() -> factory.apply(makeProperties()));
-        return this;
+        return self();
     }
 
     /**
@@ -386,12 +399,12 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @throws IllegalStateException
      *             If {@link #block()} or {@link #block(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBlock() {
+    public S defaultBlock() {
         if (this.defaultBlock != null) {
             throw new IllegalStateException("Cannot set a default block after a custom block has been created");
         }
         this.defaultBlock = true;
-        return this;
+        return self();
     }
 
     /**
@@ -399,7 +412,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public BlockBuilder<LiquidBlock, FluidBuilder<T, P>> block() {
+    public BlockBuilder<LiquidBlock, S, ?> block() {
         return block(LiquidBlock::new);
     }
 
@@ -412,7 +425,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory for the block, which accepts the block object and properties and returns a new block
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public <B extends LiquidBlock> BlockBuilder<B, FluidBuilder<T, P>> block(NonNullBiFunction<T, BlockBehaviour.Properties, ? extends B> factory) {
+    public <B extends LiquidBlock, BB extends BlockBuilder<B, S, BB>> BlockBuilder<B, S, ?> block(NonNullBiFunction<T, BlockBehaviour.Properties, ? extends B> factory) {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
@@ -420,7 +433,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
         final NonNullSupplier<T> supplier = asSupplier();
         final var lightLevel = Lazy.of(() -> fluidType.get().getLightLevel());
         final ToIntFunction<BlockState> lightLevelInt = $ -> lightLevel.get();
-        final var ret =  getOwner().<B, FluidBuilder<T, P>>block(this, sourceName, p -> factory.apply(supplier.get(), p))
+        final var ret =  getOwner().<B, S, BB>block(self(), sourceName, p -> factory.apply(supplier.get(), p))
             .properties(p -> BlockBehaviour.Properties.ofFullCopy(Blocks.WATER).noLootTable())
             .properties(p -> p.lightLevel(lightLevelInt))
                 .blockstate(() -> (ctx, prov) -> prov.createNonTemplateModelBlock(ctx.get()));
@@ -429,12 +442,12 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
     }
 
     @Beta
-    public FluidBuilder<T, P> noBlock() {
+    public S noBlock() {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
         this.defaultBlock = false;
-        return this;
+        return self();
     }
 
     /**
@@ -445,12 +458,12 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @throws IllegalStateException
      *             If {@link #bucket()} or {@link #bucket(NonNullBiFunction)} has been called before this method
      */
-    public FluidBuilder<T, P> defaultBucket() {
+    public S defaultBucket() {
         if (this.defaultBucket != null) {
             throw new IllegalStateException("Cannot set a default bucket after a custom bucket has been created");
         }
         defaultBucket = true;
-        return this;
+        return self();
     }
 
     /**
@@ -458,7 +471,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public ItemBuilder<BucketItem, FluidBuilder<T, P>> bucket() {
+    public <B extends ItemBuilder<BucketItem, S, B>> B bucket() {
         return bucket(BucketItem::new);
     }
 
@@ -471,7 +484,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      *            A factory for the bucket item, which accepts the fluid object supplier and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <I extends BucketItem> ItemBuilder<I, FluidBuilder<T, P>> bucket(NonNullBiFunction<BaseFlowingFluid, Item.Properties, ? extends I> factory) {
+    public <I extends BucketItem, B extends ItemBuilder<I, S, B>> B bucket(NonNullBiFunction<BaseFlowingFluid, Item.Properties, ? extends I> factory) {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -481,7 +494,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
         if (source == null) {
             throw new IllegalStateException("Cannot create a bucket before creating a source block");
         }
-        final var ret = getOwner().<I, FluidBuilder<T, P>>item(this, bucketName, p -> factory.apply(source.get(), p))
+        final var ret = getOwner().<I, S, B>item(self(), bucketName, p -> factory.apply(source.get(), p))
             .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
                 .model(() -> (ctx, prov) -> prov.generateFlatItem(ctx.get(), ModelTemplates.FLAT_ITEM));
         this.fluidProperties(p -> p.bucket(ret.asSupplier()));
@@ -489,12 +502,12 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
     }
 
     @Beta
-    public FluidBuilder<T, P> noBucket() {
+    public S noBucket() {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
         this.defaultBucket = false;
-        return this;
+        return self();
     }
 
     /**
@@ -505,14 +518,14 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> tag(TagKey<Fluid>... tags) {
-        FluidBuilder<T, P> ret = this.tag(ProviderType.FLUID_TAGS, tags);
+    public final S tag(TagKey<Fluid>... tags) {
+        FluidBuilder<T, P, S> ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
             ret.getOwner().<RegistrateTagsProvider.Intrinsic<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
                 prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
         }
         this.tags.addAll(Arrays.asList(tags));
-        return ret;
+        return ret.self();
     }
 
     /**
@@ -523,7 +536,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P> extends AbstractBuilder
      * @return this {@link FluidBuilder}
      */
     @SafeVarargs
-    public final FluidBuilder<T, P> removeTag(TagKey<Fluid>... tags) {
+    public final S removeTag(TagKey<Fluid>... tags) {
         this.tags.removeAll(Arrays.asList(tags));
         return this.removeTag(ProviderType.FLUID_TAGS, tags);
     }

--- a/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/FluidBuilder.java
@@ -292,6 +292,10 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
     private @Nullable NonNullSupplier<? extends BaseFlowingFluid> source;
     private final List<TagKey<Fluid>> tags = new ArrayList<>();
 
+    protected final String getSourceName() {
+        return sourceName;
+    }
+
     public FluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, FluidTypeFactory typeFactory, FluidFactory<T> fluidFactory) {
         super(owner, parent, "flowing_" + name, callback, Registries.FLUID);
         this.sourceName = name;
@@ -412,7 +416,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
      *
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public BlockBuilder<LiquidBlock, S, ?> block() {
+    public <BB extends BlockBuilder<LiquidBlock, S, BB>> BB block() {
         return block(LiquidBlock::new);
     }
 
@@ -425,7 +429,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
      *            A factory for the block, which accepts the block object and properties and returns a new block
      * @return the {@link BlockBuilder} for the {@link LiquidBlock}
      */
-    public <B extends LiquidBlock, BB extends BlockBuilder<B, S, BB>> BlockBuilder<B, S, ?> block(NonNullBiFunction<T, BlockBehaviour.Properties, ? extends B> factory) {
+    public <B extends LiquidBlock, BB extends BlockBuilder<B, S, BB>> BB block(NonNullBiFunction<T, BlockBehaviour.Properties, ? extends B> factory) {
         if (this.defaultBlock == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to block/noBlock per builder allowed");
         }
@@ -471,7 +475,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
      *
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <B extends ItemBuilder<BucketItem, S, B>> B bucket() {
+    public <IB extends ItemBuilder<BucketItem, S, IB>> IB bucket() {
         return bucket(BucketItem::new);
     }
 
@@ -484,7 +488,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
      *            A factory for the bucket item, which accepts the fluid object supplier and properties and returns a new item
      * @return the {@link ItemBuilder} for the {@link BucketItem}
      */
-    public <I extends BucketItem, B extends ItemBuilder<I, S, B>> B bucket(NonNullBiFunction<BaseFlowingFluid, Item.Properties, ? extends I> factory) {
+    public <I extends BucketItem, IB extends ItemBuilder<I, S, IB>> IB bucket(NonNullBiFunction<BaseFlowingFluid, Item.Properties, ? extends I> factory) {
         if (this.defaultBucket == Boolean.FALSE) {
             throw new IllegalStateException("Only one call to bucket/noBucket per builder allowed");
         }
@@ -494,7 +498,7 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
         if (source == null) {
             throw new IllegalStateException("Cannot create a bucket before creating a source block");
         }
-        final var ret = getOwner().<I, S, B>item(self(), bucketName, p -> factory.apply(source.get(), p))
+        final var ret = getOwner().<I, S, IB>item(self(), bucketName, p -> factory.apply(source.get(), p))
             .properties(p -> p.craftRemainder(Items.BUCKET).stacksTo(1))
                 .model(() -> (ctx, prov) -> prov.generateFlatItem(ctx.get(), ModelTemplates.FLAT_ITEM));
         this.fluidProperties(p -> p.bucket(ret.asSupplier()));
@@ -519,13 +523,13 @@ public class FluidBuilder<T extends BaseFlowingFluid, P, S extends FluidBuilder<
      */
     @SafeVarargs
     public final S tag(TagKey<Fluid>... tags) {
-        FluidBuilder<T, P, S> ret = this.tag(ProviderType.FLUID_TAGS, tags);
+        S ret = this.tag(ProviderType.FLUID_TAGS, tags);
         if (this.tags.isEmpty()) {
-            ret.getOwner().<RegistrateTagsProvider.Intrinsic<Fluid>, Fluid>setDataGenerator(ret.sourceName, getRegistryKey(), ProviderType.FLUID_TAGS,
+            ret.getOwner().<RegistrateTagsProvider.Intrinsic<Fluid>, Fluid>setDataGenerator(ret.getSourceName(), getRegistryKey(), ProviderType.FLUID_TAGS,
                 prov -> this.tags.stream().map(prov::tag).forEach(p -> p.add(getSource())));
         }
         this.tags.addAll(Arrays.asList(tags));
-        return ret.self();
+        return ret;
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -44,8 +44,10 @@ import java.util.function.Supplier;
  *            The type of item being built
  * @param <P>
  *            Parent object type
+ * @param <S>
+ *            Self type
  */
-public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, ItemBuilder<T, P>> {
+public class ItemBuilder<T extends Item, P, S extends ItemBuilder<T, P, S>> extends AbstractBuilder<Item, T, P, S> {
 
     /**
      * Create a new {@link ItemBuilder} and configure data. Used in lieu of adding side-effects to constructor, so that alternate initialization strategies can be done in subclasses.
@@ -60,6 +62,8 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *            The type of the builder
      * @param <P>
      *            Parent object type
+     * @param <S>
+     *            Self type
      * @param owner
      *            The owning {@link AbstractRegistrate} object
      * @param parent
@@ -72,9 +76,8 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *            Factory to create the item
      * @return A new {@link ItemBuilder} with reasonable default data generators.
      */
-    public static <T extends Item, P> ItemBuilder<T, P> create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<Item.Properties, T> factory) {
-        return new ItemBuilder<>(owner, parent, name, callback, factory)
-                .defaultModel().defaultLang();
+    public static <T extends Item, P, S extends ItemBuilder<T, P, S>> S create(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<Item.Properties, T> factory) {
+        return new ItemBuilder<T, P, S>(owner, parent, name, callback, factory).defaultModel().defaultLang();
     }
 
     private final NonNullFunction<Item.Properties, T> factory;
@@ -94,6 +97,11 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
         });
     }
 
+    @SuppressWarnings("unchecked")
+    protected final S self() {
+        return (S) this;
+    }
+
     /**
      * Modify the properties of the item. Modifications are done lazily, but the passed function is composed with the current one, and as such this method can be called multiple times to perform
      * different operations.
@@ -104,21 +112,21 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *            The action to perform on the properties
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> properties(NonNullUnaryOperator<Item.Properties> func) {
+    public S properties(NonNullUnaryOperator<Item.Properties> func) {
         propertiesCallback = propertiesCallback.andThen(func);
-        return this;
+        return self();
     }
 
     /**
      * Replace the initial state of the item properties, without replacing or removing any modifications done via {@link #properties(NonNullUnaryOperator)}.
      *
      * @param properties
-     *            A supplier to to create the initial properties
+     *            A supplier to create the initial properties
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> initialProperties(NonNullSupplier<Item.Properties> properties) {
+    public S initialProperties(NonNullSupplier<Item.Properties> properties) {
         initialProperties = properties;
-        return this;
+        return self();
     }
 
     /**
@@ -138,7 +146,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @deprecated Use {@link #tab(ResourceKey, NonNullBiConsumer)} which provides access to the registered item.
      */
     @Deprecated
-    public ItemBuilder<T, P> tab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeModeTabModifier> modifier) {
+    public S tab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeModeTabModifier> modifier) {
         return tab(tab, ($, m) -> modifier.accept(m));
     }
 
@@ -157,9 +165,9 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @param modifier A {@link NonNullBiConsumer consumer} accepting a context object and {@link CreativeModeTabModifier} used to update the tab
      * @return This builder
      */
-    public ItemBuilder<T, P> tab(ResourceKey<CreativeModeTab> tab, NonNullBiConsumer<DataGenContext<Item, T>, CreativeModeTabModifier> modifier) {
+    public S tab(ResourceKey<CreativeModeTab> tab, NonNullBiConsumer<DataGenContext<Item, T>, CreativeModeTabModifier> modifier) {
         creativeModeTabs.put(tab, modifier); // Should we get the current value in the map [if one exists] and .andThen() the 2 together? right now we replace any consumer that currently exists
-        return this;
+        return self();
     }
 
     /**
@@ -176,7 +184,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @return This builder
      * @see #tab(ResourceKey, NonNullBiConsumer)
      */
-    public ItemBuilder<T, P> tab(ResourceKey<CreativeModeTab> tab) {
+    public S tab(ResourceKey<CreativeModeTab> tab) {
         return tab(tab, (item, modifier) -> modifier.accept(item));
     }
 
@@ -186,9 +194,9 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @param tab A {@link ResourceKey} representing the {@link CreativeModeTab} to remove the modifier from
      * @return This builder
      */
-    public ItemBuilder<T, P> removeTab(ResourceKey<CreativeModeTab> tab) {
+    public S removeTab(ResourceKey<CreativeModeTab> tab) {
         creativeModeTabs.remove(tab);
-        return this;
+        return self();
     }
 
     // TODO <1.21.4> alternate item coloring helper?
@@ -198,7 +206,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> defaultModel() {
+    public S defaultModel() {
         return model(() -> (ctx, prov) -> prov.generateFlatItem(ctx.get(), ModelTemplates.FLAT_ITEM));
     }
 
@@ -210,8 +218,8 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @return this {@link ItemBuilder}
      * @see #setData(GeneratorType, NonNullBiConsumer)
      */
-    public ItemBuilder<T, P> model(NonNullSupplier<NonNullBiConsumer<DataGenContext<Item, T>, RegistrateItemModelGenerator>> cons) {
-        if (!getOwner().doDatagen().get()) return this;
+    public S model(NonNullSupplier<NonNullBiConsumer<DataGenContext<Item, T>, RegistrateItemModelGenerator>> cons) {
+        if (!getOwner().doDatagen().get()) return self();
         return setData(ProviderType.ITEM_MODEL, cons.get());
     }
 
@@ -221,7 +229,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> defaultLang() {
+    public S defaultLang() {
         return lang(Item::getDescriptionId);
     }
 
@@ -232,7 +240,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *            A localized English name
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> lang(String name) {
+    public S lang(String name) {
         return lang(Item::getDescriptionId, name);
     }
 
@@ -244,7 +252,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @return this {@link ItemBuilder}
      * @see #setData(GeneratorType, NonNullBiConsumer)
      */
-    public ItemBuilder<T, P> recipe(NonNullBiConsumer<DataGenContext<Item, T>, RegistrateRecipeProvider> cons) {
+    public S recipe(NonNullBiConsumer<DataGenContext<Item, T>, RegistrateRecipeProvider> cons) {
         return setData(ProviderType.RECIPE, cons);
     }
 
@@ -252,7 +260,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * Add burn time for the item
      * @param tick time in ticks for this item to burn in furnace.
      */
-    public ItemBuilder<T, P> burnTime(int tick) {
+    public S burnTime(int tick) {
         return dataMap(NeoForgeDataMaps.FURNACE_FUELS, new FurnaceFuel(tick));
     }
 
@@ -260,7 +268,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * Add compost chance for the item
      * @param chance chance for composter to increase one level when composting this item.
      */
-    public ItemBuilder<T, P> compostable(float chance) {
+    public S compostable(float chance) {
         return dataMap(NeoForgeDataMaps.COMPOSTABLES, new Compostable(chance));
     }
 
@@ -273,21 +281,21 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      *            The client extension to register for this item
      * @return this {@link ItemBuilder}
      */
-    public ItemBuilder<T, P> clientExtension(NonNullSupplier<Supplier<IClientItemExtensions>> clientExtension) {
+    public S clientExtension(NonNullSupplier<Supplier<IClientItemExtensions>> clientExtension) {
         if (this.clientExtensionFunc == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientExtension);
         }
         this.clientExtensionFunc = item -> clientExtension;
-        return this;
+        return self();
     }
 
     @Deprecated(forRemoval = true)
-    public ItemBuilder<T, P> clientExtension(Function<T, NonNullSupplier<Supplier<IClientItemExtensions>>> clientExtension) {
+    public S clientExtension(Function<T, NonNullSupplier<Supplier<IClientItemExtensions>>> clientExtension) {
         if (this.clientExtensionFunc == null) {
             RegistrateDistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientExtension);
         }
         this.clientExtensionFunc = clientExtension;
-        return this;
+        return self();
     }
 
     protected void registerClientExtension() {
@@ -307,7 +315,7 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
      * @return this {@link ItemBuilder}
      */
     @SafeVarargs
-    public final ItemBuilder<T, P> tag(TagKey<Item>... tags) {
+    public final S tag(TagKey<Item>... tags) {
         return tag(ProviderType.ITEM_TAGS, tags);
     }
 

--- a/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
+++ b/src/test/java/com/tterrag/registrate/test/mod/TestMod.java
@@ -383,7 +383,7 @@ public class TestMod {
 //            .block(Block::new)
 //            .addLayer(() -> RenderType::getTranslucent);
 
-    private static <T extends Block, P> BlockBuilder<T, P> applyDiamondDrop(BlockBuilder<T, P> builder) {
+    private static <T extends Block, P, B extends BlockBuilder<T, P, B>> B applyDiamondDrop(B builder) {
         return builder.loot((prov, block) -> prov.dropOther(block, Items.DIAMOND));
     }
 


### PR DESCRIPTION
this pr adds self type parameters to the builders list above. the addition of these type parameters allows for easier use of subclasses of these types, as their methods now return the subclass type instead of the base type.

```java
public class CustomBlockBuilder<T extends Block, P> extends BlockBuilder<T, P, CustomBlockBuilder<T, P>> {
    protected CustomBlockBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback, NonNullFunction<BlockBehaviour.Properties, T> factory, NonNullSupplier<BlockBehaviour.Properties> initialProperties) {
        super(owner, parent, name, callback, factory, initialProperties);
    }
}
```
originally, calling CustomBlockBuilder#defaultBlockState would have returned BlockBuilder, so chaining this would require overrides and casts to maintain the type. now, the method would return CustomBlockBuilder, allowing for easier chaining.