### PR TITLE
Port Registrate to Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 org.gradle.caching=true
 
-mod_version=1.6.x
+mod_version=1.6.0
 release_minecraft_version=26.2
-neo_version=26.2.0.6-beta
+neo_version=26.2.0.8-beta

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/BlockBuilder.java
@@ -30,6 +30,7 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 
 import net.minecraft.client.color.block.BlockTintSource;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.block.dispatch.SingleVariant;
 import net.minecraft.client.renderer.block.dispatch.Variant;
 import net.minecraft.core.registries.Registries;
@@ -219,6 +220,14 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
         this.tintSources = tintSources;
         return this;
     }
+
+    public BlockBuilder<T, P> addLayer(NonNullSupplier<Supplier<RenderType>> renderType) {
+        return this;
+    }
+
+    public BlockBuilder<T, P> addLayer(Supplier<Supplier<RenderType>> renderType) {
+        return addLayer(NonNullSupplier.of(renderType));
+    }
     
     protected void registerBlockColor() {
         OneTimeEventReceiver.addModListener(getOwner(), RegisterColorHandlersEvent.BlockTintSources.class, e -> {
@@ -250,6 +259,10 @@ public class BlockBuilder<T extends Block, P> extends AbstractBuilder<Block, T, 
     public BlockBuilder<T, P> blockstate(NonNullSupplier<NonNullBiConsumer<DataGenContext<Block, T>, RegistrateBlockModelGenerator>> cons) {
         if (!getOwner().doDatagen().get()) return this;
         return setData(ProviderType.BLOCKSTATE, cons.get());
+    }
+
+    public BlockBuilder<T, P> blockstate(NonNullBiConsumer<DataGenContext<Block, T>, RegistrateBlockModelGenerator> cons) {
+        return blockstate(() -> cons);
     }
 
     /**

--- a/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
+++ b/src/main/java/com/tterrag/registrate/builders/ItemBuilder.java
@@ -193,6 +193,10 @@ public class ItemBuilder<T extends Item, P> extends AbstractBuilder<Item, T, P, 
         return setData(ProviderType.ITEM_MODEL, cons.get());
     }
 
+    public ItemBuilder<T, P> model(NonNullBiConsumer<DataGenContext<Item, T>, RegistrateItemModelGenerator> cons) {
+        return model(() -> cons);
+    }
+
     /**
      * Assign the default translation, as specified by {@link RegistrateLangProvider#getAutomaticName(NonNullSupplier, net.minecraft.resources.ResourceKey)}. This is the default, so it is generally
      * not necessary to call, unless for undoing previous changes.

--- a/src/main/java/com/tterrag/registrate/providers/ProviderType.java
+++ b/src/main/java/com/tterrag/registrate/providers/ProviderType.java
@@ -51,7 +51,7 @@ public interface ProviderType<T extends RegistrateProvider> extends GeneratorTyp
 
     // CLIENT DATA
     ProviderType<RegistrateModelProvider> MODEL = registerClientProvider("model", () -> c -> new RegistrateModelProvider(c.parent(), c.output()));
-    ProviderType<RegistrateLangProvider> LANG = registerClientProvider("lang", () -> c -> new RegistrateLangProvider(c.parent(), c.output()));
+    ProviderType<RegistrateLangProvider> LANG = registerClientProvider("lang", () -> c -> new RegistrateLangProvider(c.parent(), c.output(), c.provider()));
     ProviderType<RegistrateGenericProvider> GENERIC_CLIENT = registerClientProvider("registrate_generic_client_provider", () -> c -> new RegistrateGenericProvider(c.parent(), c.event(), c.type()));
 
     GeneratorType<RegistrateRecipeProvider> RECIPE = RECIPE_RUNNER.createGenerator("recipe");

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateLangProvider.java
@@ -2,6 +2,8 @@ package com.tterrag.registrate.providers;
 
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -43,13 +45,24 @@ public class RegistrateLangProvider extends LanguageProvider implements Registra
     }
 
     private final AbstractRegistrate<?> owner;
+    private final CompletableFuture<HolderLookup.Provider> registriesLookup;
 
     private final AccessibleLanguageProvider upsideDown;
 
     public RegistrateLangProvider(AbstractRegistrate<?> owner, PackOutput packOutput) {
+        this(owner, packOutput, CompletableFuture.completedFuture(RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY)));
+    }
+
+    public RegistrateLangProvider(AbstractRegistrate<?> owner, PackOutput packOutput,
+                                  CompletableFuture<HolderLookup.Provider> registriesLookup) {
         super(packOutput, owner.getModid(), "en_us");
         this.owner = owner;
+        this.registriesLookup = registriesLookup;
         this.upsideDown = new AccessibleLanguageProvider(packOutput, owner.getModid(), "en_ud");
+    }
+
+    public CompletableFuture<HolderLookup.Provider> getRegistriesLookup() {
+        return registriesLookup;
     }
 
     @Override

--- a/src/main/java/com/tterrag/registrate/providers/generators/BlockModelBuilder.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/BlockModelBuilder.java
@@ -1,0 +1,12 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.function.BiConsumer;
+
+import net.minecraft.client.data.models.model.ModelInstance;
+import net.minecraft.resources.Identifier;
+
+public class BlockModelBuilder extends ModelBuilder<BlockModelBuilder> {
+	public BlockModelBuilder(Identifier location, BiConsumer<Identifier, ModelInstance> output) {
+		super(location, output);
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/BlockModelProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/BlockModelProvider.java
@@ -1,0 +1,64 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.function.BiConsumer;
+
+import net.minecraft.client.data.models.model.ModelInstance;
+import net.minecraft.resources.Identifier;
+
+public class BlockModelProvider extends ModelProvider {
+	private final String modid;
+	private final BiConsumer<Identifier, ModelInstance> output;
+
+	public BlockModelProvider(String modid, BiConsumer<Identifier, ModelInstance> output) {
+		this.modid = modid;
+		this.output = output;
+	}
+
+	public Identifier mcLoc(String path) {
+		return Identifier.withDefaultNamespace(path);
+	}
+
+	public Identifier modLoc(String path) {
+		return Identifier.fromNamespaceAndPath(modid, path);
+	}
+
+	public ModelFile.ExistingModelFile getExistingFile(Identifier location) {
+		return new ModelFile.ExistingModelFile(location);
+	}
+
+	public BlockModelBuilder getBuilder(String name) {
+		return new BlockModelBuilder(resolve(name), output);
+	}
+
+	public BlockModelBuilder withExistingParent(String name, Identifier parent) {
+		return getBuilder(name).parent(parent);
+	}
+
+	public BlockModelBuilder withExistingParent(String name, String parent) {
+		return getBuilder(name).parent(parent);
+	}
+
+	public BlockModelBuilder cubeAll(String name, Identifier texture) {
+		return withExistingParent(name, mcLoc("block/cube_all")).texture("all", texture);
+	}
+
+	public BlockModelBuilder cubeColumn(String name, Identifier side, Identifier end) {
+		return withExistingParent(name, mcLoc("block/cube_column"))
+			.texture("side", side)
+			.texture("end", end);
+	}
+
+	public BlockModelBuilder singleTexture(String name, Identifier parent, String textureKey, Identifier texture) {
+		return withExistingParent(name, parent).texture(textureKey, texture);
+	}
+
+	private Identifier resolve(String name) {
+		if (name.contains(":")) {
+			return Identifier.parse(name);
+		}
+		if (name.startsWith(BLOCK_FOLDER + "/") || name.startsWith(ITEM_FOLDER + "/")) {
+			return modLoc(name);
+		}
+		return modLoc(BLOCK_FOLDER + "/" + name);
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/BlockStateProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/BlockStateProvider.java
@@ -1,0 +1,5 @@
+package com.tterrag.registrate.providers.generators;
+
+public interface BlockStateProvider {
+	BlockModelProvider models();
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/ConfiguredModel.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/ConfiguredModel.java
@@ -1,0 +1,89 @@
+package com.tterrag.registrate.providers.generators;
+
+import com.mojang.math.Quadrant;
+
+import net.minecraft.client.data.models.BlockModelGenerators;
+import net.minecraft.client.data.models.MultiVariant;
+import net.minecraft.client.renderer.block.dispatch.Variant;
+
+public class ConfiguredModel {
+	private final ModelFile modelFile;
+	private final int rotationX;
+	private final int rotationY;
+	private final boolean uvLock;
+
+	public ConfiguredModel(ModelFile modelFile, int rotationX, int rotationY, boolean uvLock) {
+		this.modelFile = modelFile;
+		this.rotationX = rotationX;
+		this.rotationY = rotationY;
+		this.uvLock = uvLock;
+	}
+
+	public MultiVariant toMultiVariant() {
+		Variant variant = new Variant(modelFile.getLocation());
+		variant = variant.withXRot(toQuadrant(rotationX));
+		variant = variant.withYRot(toQuadrant(rotationY));
+		variant = variant.withUvLock(uvLock);
+		return BlockModelGenerators.variant(variant);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private static Quadrant toQuadrant(int degrees) {
+		int normalized = Math.floorMod(degrees, 360);
+		return switch (normalized) {
+			case 90 -> Quadrant.R90;
+			case 180 -> Quadrant.R180;
+			case 270 -> Quadrant.R270;
+			default -> Quadrant.R0;
+		};
+	}
+
+	public static class Builder {
+		private final java.util.List<ConfiguredModel> models = new java.util.ArrayList<>();
+		private ModelFile modelFile;
+		private int rotationX;
+		private int rotationY;
+		private boolean uvLock;
+
+		public Builder modelFile(ModelFile modelFile) {
+			this.modelFile = modelFile;
+			return this;
+		}
+
+		public Builder rotationX(int rotationX) {
+			this.rotationX = rotationX;
+			return this;
+		}
+
+		public Builder rotationY(int rotationY) {
+			this.rotationY = rotationY;
+			return this;
+		}
+
+		public Builder uvLock(boolean uvLock) {
+			this.uvLock = uvLock;
+			return this;
+		}
+
+		public Builder nextModel() {
+			models.add(buildLast());
+			modelFile = null;
+			rotationX = 0;
+			rotationY = 0;
+			uvLock = false;
+			return this;
+		}
+
+		public ConfiguredModel buildLast() {
+			return new ConfiguredModel(modelFile, rotationX, rotationY, uvLock);
+		}
+
+		public ConfiguredModel[] build() {
+			models.add(buildLast());
+			return models.toArray(ConfiguredModel[]::new);
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/ItemModelBuilder.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/ItemModelBuilder.java
@@ -1,0 +1,71 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import net.minecraft.client.data.models.model.ModelInstance;
+import net.minecraft.resources.Identifier;
+
+public class ItemModelBuilder extends ModelBuilder<ItemModelBuilder> {
+	private final List<OverrideBuilder> overrides = new ArrayList<>();
+
+	public ItemModelBuilder(Identifier location, BiConsumer<Identifier, ModelInstance> output) {
+		super(location, output);
+	}
+
+	public OverrideBuilder override() {
+		OverrideBuilder builder = new OverrideBuilder(this);
+		overrides.add(builder);
+		return builder;
+	}
+
+	@Override
+	protected JsonObject toJson() {
+		JsonObject root = super.toJson();
+		if (!overrides.isEmpty()) {
+			JsonArray overridesJson = new JsonArray();
+			for (OverrideBuilder override : overrides) {
+				overridesJson.add(override.toJson());
+			}
+			root.add("overrides", overridesJson);
+		}
+		return root;
+	}
+
+	public static class OverrideBuilder {
+		private final ItemModelBuilder parent;
+		private final JsonObject predicates = new JsonObject();
+		private Identifier model;
+
+		OverrideBuilder(ItemModelBuilder parent) {
+			this.parent = parent;
+		}
+
+		public OverrideBuilder predicate(Identifier id, float value) {
+			predicates.addProperty(id.toString(), value);
+			return this;
+		}
+
+		public OverrideBuilder model(ModelFile model) {
+			this.model = model.getLocation();
+			return this;
+		}
+
+		public ItemModelBuilder end() {
+			return parent.flush();
+		}
+
+		JsonObject toJson() {
+			JsonObject root = new JsonObject();
+			root.add("predicate", predicates);
+			if (model != null) {
+				root.addProperty("model", model.toString());
+			}
+			return root;
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/ModelBuilder.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/ModelBuilder.java
@@ -1,0 +1,124 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.client.data.models.model.ModelInstance;
+import net.minecraft.resources.Identifier;
+
+@SuppressWarnings("unchecked")
+public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
+	protected final BiConsumer<Identifier, ModelInstance> output;
+	protected Identifier parent;
+	protected final Map<String, String> textures = new LinkedHashMap<>();
+	private boolean registered;
+
+	public ModelBuilder(Identifier location, BiConsumer<Identifier, ModelInstance> output) {
+		super(location);
+		this.output = output;
+		flush();
+	}
+
+	public T parent(ModelFile parent) {
+		this.parent = parent.getLocation();
+		return flush();
+	}
+
+	public T parent(Identifier parent) {
+		this.parent = parent;
+		return flush();
+	}
+
+	public T parent(String parent) {
+		return parent(parent.contains(":") ? Identifier.parse(parent) : Identifier.withDefaultNamespace(parent));
+	}
+
+	public T texture(String key, Identifier texture) {
+		textures.put(key, texture.toString());
+		return flush();
+	}
+
+	public T texture(String key, String texture) {
+		textures.put(key, texture);
+		return flush();
+	}
+
+	public ElementBuilder<T> element() {
+		return new ElementBuilder<>((T) this);
+	}
+
+	protected T flush() {
+		if (output != null && !registered) {
+			registered = true;
+			output.accept(getLocation(), this::toJson);
+		}
+		return (T) this;
+	}
+
+	protected JsonObject toJson() {
+		JsonObject root = new JsonObject();
+		if (parent != null) {
+			root.addProperty("parent", parent.toString());
+		}
+		if (!textures.isEmpty()) {
+			JsonObject textureObj = new JsonObject();
+			textures.forEach(textureObj::addProperty);
+			root.add("textures", textureObj);
+		}
+		return root;
+	}
+
+	public static class ElementBuilder<P extends ModelBuilder<P>> {
+		private final P parent;
+
+		ElementBuilder(P parent) {
+			this.parent = parent;
+		}
+
+		public ElementBuilder<P> from(float x, float y, float z) {
+			return this;
+		}
+
+		public ElementBuilder<P> to(float x, float y, float z) {
+			return this;
+		}
+
+		public FaceBuilder<ElementBuilder<P>> face(net.minecraft.core.Direction direction) {
+			return new FaceBuilder<>(this);
+		}
+
+		public ElementBuilder<P> faces(BiConsumer<net.minecraft.core.Direction, FaceBuilder<ElementBuilder<P>>> action) {
+			for (net.minecraft.core.Direction direction : net.minecraft.core.Direction.values()) {
+				action.accept(direction, new FaceBuilder<>(this));
+			}
+			return this;
+		}
+
+		public P end() {
+			return parent.flush();
+		}
+	}
+
+	public static class FaceBuilder<P> {
+		private final P parent;
+
+		FaceBuilder(P parent) {
+			this.parent = parent;
+		}
+
+		public FaceBuilder<P> uvs(float u1, float v1, float u2, float v2) {
+			return this;
+		}
+
+		public FaceBuilder<P> texture(String texture) {
+			return this;
+		}
+
+		public P end() {
+			return parent;
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/ModelFile.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/ModelFile.java
@@ -1,0 +1,31 @@
+package com.tterrag.registrate.providers.generators;
+
+import net.minecraft.resources.Identifier;
+
+public class ModelFile {
+	private final Identifier location;
+
+	public ModelFile(Identifier location) {
+		this.location = location;
+	}
+
+	public Identifier getLocation() {
+		return location;
+	}
+
+	public static class ExistingModelFile extends ModelFile {
+		public ExistingModelFile(Identifier location) {
+			super(location);
+		}
+	}
+
+	public static class UncheckedModelFile extends ModelFile {
+		public UncheckedModelFile(String location) {
+			super(location.contains(":") ? Identifier.parse(location) : Identifier.withDefaultNamespace(location));
+		}
+
+		public UncheckedModelFile(Identifier location) {
+			super(location);
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/ModelProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/ModelProvider.java
@@ -1,0 +1,6 @@
+package com.tterrag.registrate.providers.generators;
+
+public class ModelProvider {
+	public static final String BLOCK_FOLDER = "block";
+	public static final String ITEM_FOLDER = "item";
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/MultiPartBlockStateBuilder.java
@@ -1,0 +1,126 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.client.data.models.MultiVariant;
+import net.minecraft.client.data.models.blockstates.BlockModelDefinitionGenerator;
+import net.minecraft.client.data.models.blockstates.ConditionBuilder;
+import net.minecraft.client.data.models.blockstates.MultiPartGenerator;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.properties.Property;
+
+public class MultiPartBlockStateBuilder {
+	private final RegistrateBlockModelGenerator owner;
+	private final Block block;
+	private final List<PartBuilder> parts = new ArrayList<>();
+	private final BlockModelDefinitionGenerator generator = new BlockModelDefinitionGenerator() {
+		@Override
+		public Block block() {
+			return block;
+		}
+
+		@Override
+		public BlockStateModelDispatcher create() {
+			return createGenerator().create();
+		}
+	};
+	private boolean registered;
+
+	MultiPartBlockStateBuilder(RegistrateBlockModelGenerator owner, Block block) {
+		this.owner = owner;
+		this.block = block;
+	}
+
+	public PartBuilder part() {
+		PartBuilder part = new PartBuilder(this);
+		parts.add(part);
+		return part;
+	}
+
+	private MultiPartGenerator createGenerator() {
+		MultiPartGenerator generator = MultiPartGenerator.multiPart(block);
+		for (PartBuilder part : parts) {
+			MultiVariant variant = part.model.toMultiVariant();
+			if (part.condition == null) {
+				generator.with(variant);
+			} else {
+				generator.with(part.condition, variant);
+			}
+		}
+		return generator;
+	}
+
+	private void flush() {
+		if (!registered) {
+			registered = true;
+			owner.blockStateOutput.accept(generator);
+		} else {
+			owner.seenBlockstates.put(block, generator.create());
+		}
+	}
+
+	public static class PartBuilder {
+		private final MultiPartBlockStateBuilder parent;
+		private ConfiguredModel model;
+		private ConditionBuilder condition;
+		private ModelFile modelFile;
+		private int rotationX;
+		private int rotationY;
+		private boolean uvLock;
+
+		PartBuilder(MultiPartBlockStateBuilder parent) {
+			this.parent = parent;
+		}
+
+		public PartBuilder modelFile(ModelFile modelFile) {
+			this.modelFile = modelFile;
+			return this;
+		}
+
+		public PartBuilder rotationX(int rotationX) {
+			this.rotationX = rotationX;
+			return this;
+		}
+
+		public PartBuilder rotationY(int rotationY) {
+			this.rotationY = rotationY;
+			return this;
+		}
+
+		public PartBuilder uvLock(boolean uvLock) {
+			this.uvLock = uvLock;
+			return this;
+		}
+
+		public PartBuilder addModel() {
+			model = new ConfiguredModel(modelFile, rotationX, rotationY, uvLock);
+			return this;
+		}
+
+		@SafeVarargs
+		public final <T extends Comparable<T>> PartBuilder condition(Property<T> property, T value,
+			T... additionalValues) {
+			if (condition == null) {
+				condition = new ConditionBuilder();
+			}
+			condition.term(property, value, additionalValues);
+			return this;
+		}
+
+		public PartBuilder condition(Property<Boolean> property, boolean value) {
+			if (condition == null) {
+				condition = new ConditionBuilder();
+			}
+			condition.term(property, value);
+			return this;
+		}
+
+		public MultiPartBlockStateBuilder end() {
+			parent.flush();
+			return parent;
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/generators/RegistrateBlockModelGenerator.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/RegistrateBlockModelGenerator.java
@@ -48,9 +48,10 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class RegistrateBlockModelGenerator extends BlockModelGenerators {
+public class RegistrateBlockModelGenerator extends BlockModelGenerators implements BlockStateProvider {
 
     private final AbstractRegistrate<?> parent;
+    private final BlockModelProvider legacyModels;
     public final Map<Block, BlockStateModelDispatcher> seenBlockstates = new HashMap<>();
 
     public RegistrateBlockModelGenerator(AbstractRegistrate<?> parent, Consumer<BlockModelDefinitionGenerator> known, ItemModelOutput item, BiConsumer<Identifier, ModelInstance> model) {
@@ -60,6 +61,7 @@ public class RegistrateBlockModelGenerator extends BlockModelGenerators {
             known.accept(g);
         }, "blockStateOutput");
         this.parent = parent;
+        this.legacyModels = new BlockModelProvider(parent.getModid(), model);
     }
 
     @Override
@@ -78,6 +80,85 @@ public class RegistrateBlockModelGenerator extends BlockModelGenerators {
 
     public Identifier modLoc(String id) {
         return Identifier.fromNamespaceAndPath(parent.getModid(), id);
+    }
+
+    @Override
+    public BlockModelProvider models() {
+        return legacyModels;
+    }
+
+    public VariantBlockStateBuilder getVariantBuilder(Block block) {
+        return new VariantBlockStateBuilder(this, block);
+    }
+
+    public MultiPartBlockStateBuilder getMultipartBuilder(Block block) {
+        return new MultiPartBlockStateBuilder(this, block);
+    }
+
+    public void simpleBlock(Block block, ModelFile model) {
+        blockStateOutput.accept(createSimpleBlock(block, plainVariant(model.getLocation())));
+    }
+
+    public void simpleBlock(Block block, ConfiguredModel... models) {
+        if (models.length == 0) {
+            generate(block, TexturedModel.CUBE);
+            return;
+        }
+        blockStateOutput.accept(createSimpleBlock(block, models[0].toMultiVariant()));
+    }
+
+    public void horizontalBlock(Block block, ModelFile model) {
+        generateHorizontalBlock(block, plainVariant(model.getLocation()));
+    }
+
+    public void horizontalBlock(Block block, ModelFile model, int angleOffset) {
+        blockStateOutput.accept(MultiVariantGenerator.dispatch(block, plainVariant(model.getLocation()))
+                .with(rotationHorizontalFacing(angleOffset)));
+    }
+
+    public void horizontalBlock(Block block, java.util.function.Function<net.minecraft.world.level.block.state.BlockState, ModelFile> modelFunc) {
+        getVariantBuilder(block).forAllStates(state -> ConfiguredModel.builder()
+            .modelFile(modelFunc.apply(state))
+            .rotationY(((int) state.getValue(BlockStateProperties.HORIZONTAL_FACING).toYRot() + 180) % 360)
+            .build());
+    }
+
+    public void horizontalFaceBlock(Block block, ModelFile model) {
+        blockStateOutput.accept(MultiVariantGenerator.dispatch(block, plainVariant(model.getLocation()))
+                .with(rotationAttachFaceAndHorizontalFacing(180)));
+    }
+
+    public void horizontalFaceBlock(Block block, java.util.function.Function<net.minecraft.world.level.block.state.BlockState, ModelFile> modelFunc) {
+        getVariantBuilder(block).forAllStates(state -> {
+            AttachFace attachFace = state.getValue(BlockStateProperties.ATTACH_FACE);
+            Direction direction = state.getValue(BlockStateProperties.HORIZONTAL_FACING);
+            int rotationX = switch (attachFace) {
+                case FLOOR -> 0;
+                case WALL -> 90;
+                case CEILING -> 180;
+            };
+            int rotationY = ((int) direction.toYRot() + (attachFace == AttachFace.CEILING ? 0 : 180)) % 360;
+            return ConfiguredModel.builder()
+                .modelFile(modelFunc.apply(state))
+                .rotationX(rotationX)
+                .rotationY(rotationY)
+                .build();
+        });
+    }
+
+    public void directionalBlock(Block block, ModelFile model) {
+        generateDirectionalBlock(block, plainVariant(model.getLocation()));
+    }
+
+    public void directionalBlock(Block block, java.util.function.Function<net.minecraft.world.level.block.state.BlockState, ModelFile> modelFunc) {
+        getVariantBuilder(block).forAllStates(state -> {
+            Direction direction = state.getValue(BlockStateProperties.FACING);
+            return ConfiguredModel.builder()
+                .modelFile(modelFunc.apply(state))
+                .rotationX(direction == Direction.DOWN ? 180 : direction.getAxis().isHorizontal() ? 90 : 0)
+                .rotationY(direction.getAxis().isVertical() ? 0 : (((int) direction.toYRot()) + 180) % 360)
+                .build();
+        });
     }
 
     public Material mcBlockTexture(String path) {
@@ -145,6 +226,10 @@ public class RegistrateBlockModelGenerator extends BlockModelGenerators {
 
     public void generateAxisBlock(RotatedPillarBlock block, Material side, Material end) {
         generateAxisBlockInternal(block, side, end, ModelTemplates.CUBE_COLUMN, ModelTemplates.CUBE_COLUMN_HORIZONTAL);
+    }
+
+    public void axisBlock(RotatedPillarBlock block, Identifier side, Identifier end) {
+        generateAxisBlock(block, new Material(side), new Material(end));
     }
 
     private void generateAxisBlockInternal(RotatedPillarBlock block, Material side, Material end, ModelTemplate cubeColumn, ModelTemplate cubeColumnHorizontal) {
@@ -431,6 +516,10 @@ public class RegistrateBlockModelGenerator extends BlockModelGenerators {
         );
     }
 
+    public void paneBlock(IronBarsBlock block, Identifier pane, Identifier edge) {
+        generatePaneBlock(block, new Material(pane), new Material(edge));
+    }
+
     public void generatePaneBlock(IronBarsBlock block, String name, Material pane, Material edge) {
         Identifier baseName = modLoc(name + "_pane");
         generatePaneBlockInternal(block, baseName, pane, edge, ModelTemplates.STAINED_GLASS_PANE_POST, ModelTemplates.STAINED_GLASS_PANE_SIDE, ModelTemplates.STAINED_GLASS_PANE_SIDE_ALT, ModelTemplates.STAINED_GLASS_PANE_NOSIDE, ModelTemplates.STAINED_GLASS_PANE_NOSIDE_ALT);
@@ -459,6 +548,16 @@ public class RegistrateBlockModelGenerator extends BlockModelGenerators {
                 .with(condition().term(BlockStateProperties.EAST, false), noSideAlt)
                 .with(condition().term(BlockStateProperties.SOUTH, false), noSideAlt.with(Y_ROT_90))
                 .with(condition().term(BlockStateProperties.WEST, false), noSide.with(Y_ROT_270))
+        );
+    }
+
+    public void paneBlock(IronBarsBlock block, ModelFile post, ModelFile side, ModelFile sideAlt, ModelFile noSide, ModelFile noSideAlt) {
+        generatePaneBlock(block,
+                plainVariant(post.getLocation()),
+                plainVariant(side.getLocation()),
+                plainVariant(sideAlt.getLocation()),
+                plainVariant(noSide.getLocation()),
+                plainVariant(noSideAlt.getLocation())
         );
     }
 

--- a/src/main/java/com/tterrag/registrate/providers/generators/RegistrateItemModelGenerator.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/RegistrateItemModelGenerator.java
@@ -1,6 +1,7 @@
 package com.tterrag.registrate.providers.generators;
 
 import com.tterrag.registrate.AbstractRegistrate;
+import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import net.minecraft.client.color.item.ItemTintSource;
@@ -19,12 +20,14 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.client.model.item.DynamicFluidContainerModel;
 import net.neoforged.neoforge.common.NeoForgeMod;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
+import java.util.function.Supplier;
 
 public class RegistrateItemModelGenerator extends ItemModelGenerators {
 
@@ -44,6 +47,73 @@ public class RegistrateItemModelGenerator extends ItemModelGenerators {
 
     public void createWithExistingModel(Item item, Identifier id) {
         itemModelOutput.accept(item, ItemModelUtils.plainModel(id));
+    }
+
+    public ModelFile.ExistingModelFile getExistingFile(Identifier location) {
+        return new ModelFile.ExistingModelFile(location);
+    }
+
+    public ItemModelBuilder getBuilder(String name) {
+        return new ItemModelBuilder(resolve(name), modelOutput);
+    }
+
+    public ItemModelBuilder withExistingParent(String name, Identifier parent) {
+        ItemModelBuilder builder = getBuilder(name).parent(parent);
+        return builder;
+    }
+
+    public ItemModelBuilder withExistingParent(String name, String parent) {
+        return getBuilder(name).parent(parent);
+    }
+
+    public ItemModelBuilder generated(DataGenContext<Item, ? extends Item> ctx) {
+        return generated(ctx::get);
+    }
+
+    public ItemModelBuilder generated(DataGenContext<Item, ? extends Item> ctx, Identifier texture) {
+        return generated(ctx::get, texture);
+    }
+
+    public ItemModelBuilder generated(NonNullSupplier<? extends Item> item) {
+        return generated(item, modItemTexture(name(item)).sprite());
+    }
+
+    public ItemModelBuilder generated(NonNullSupplier<? extends Item> item, Identifier texture) {
+        ItemModelBuilder builder = withExistingParent(name(item), mcLoc("item/generated"))
+            .texture("layer0", texture);
+        itemModelOutput.accept(item.get(), ItemModelUtils.plainModel(builder.getLocation()));
+        return builder;
+    }
+
+    public ItemModelBuilder blockItem(Supplier<? extends Block> block, String suffix) {
+        Identifier model = ModelLocationUtils.getModelLocation(block.get(), suffix);
+        Item item = block.get().asItem();
+        ItemModelBuilder builder = withExistingParent(BuiltInRegistries.ITEM.getKey(item).getPath(), model);
+        itemModelOutput.accept(item, ItemModelUtils.plainModel(builder.getLocation()));
+        return builder;
+    }
+
+    public ItemModelBuilder blockSprite(DataGenContext<Item, ? extends Item> ctx, Identifier texture) {
+        return blockSprite(ctx::get, texture);
+    }
+
+    public ItemModelBuilder blockSprite(NonNullSupplier<? extends Item> item, Identifier texture) {
+        return generated(item, texture);
+    }
+
+    public ItemModelBuilder cubeAll(String name, Identifier texture) {
+        return withExistingParent(name, mcLoc("block/cube_all")).texture("all", texture);
+    }
+
+    public ItemModelBuilder cubeColumn(String name, Identifier side, Identifier end) {
+        return withExistingParent(name, mcLoc("block/cube_column"))
+            .texture("side", side)
+            .texture("end", end);
+    }
+
+    public ItemModelBuilder wallInventory(String name, Identifier texture) {
+        return withExistingParent(name, mcLoc("block/wall_inventory"))
+            .texture("wall", texture);
     }
 
     public void generateWithTemplate(Item item, ModelTemplate template, TextureMapping textures) {
@@ -96,6 +166,16 @@ public class RegistrateItemModelGenerator extends ItemModelGenerators {
 
     public Material modItemTexture(String path) {
         return new Material(modLoc("item/" + path));
+    }
+
+    private Identifier resolve(String name) {
+        if (name.contains(":")) {
+            return Identifier.parse(name);
+        }
+        if (name.startsWith(ModelProvider.BLOCK_FOLDER + "/") || name.startsWith(ModelProvider.ITEM_FOLDER + "/")) {
+            return modLoc(name);
+        }
+        return modLoc(ModelProvider.ITEM_FOLDER + "/" + name);
     }
 
     public String modid(NonNullSupplier<? extends ItemLike> item) {

--- a/src/main/java/com/tterrag/registrate/providers/generators/VariantBlockStateBuilder.java
+++ b/src/main/java/com/tterrag/registrate/providers/generators/VariantBlockStateBuilder.java
@@ -1,0 +1,71 @@
+package com.tterrag.registrate.providers.generators;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import net.minecraft.client.data.models.MultiVariant;
+import net.minecraft.client.data.models.blockstates.PropertyValueList;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+public class VariantBlockStateBuilder {
+	private final RegistrateBlockModelGenerator owner;
+	private final Block block;
+
+	VariantBlockStateBuilder(RegistrateBlockModelGenerator owner, Block block) {
+		this.owner = owner;
+		this.block = block;
+	}
+
+	public VariantBlockStateBuilder forAllStates(Function<BlockState, ConfiguredModel[]> mapper) {
+		Map<String, BlockStateModel.Unbaked> entries = new LinkedHashMap<>();
+		for (BlockState state : block.getStateDefinition().getPossibleStates()) {
+			entries.put(key(state), combine(mapper.apply(state)).toUnbaked());
+		}
+		owner.blockStateOutput.accept(new SimpleGenerator(block, entries));
+		return this;
+	}
+
+	@SafeVarargs
+	public final VariantBlockStateBuilder forAllStatesExcept(Function<BlockState, ConfiguredModel[]> mapper,
+		Property<?>... ignored) {
+		return forAllStates(mapper);
+	}
+
+	public PartialBlockstate partialState() {
+		return new PartialBlockstate();
+	}
+
+	private static MultiVariant combine(ConfiguredModel[] models) {
+		if (models == null || models.length == 0) {
+			throw new IllegalStateException("No models supplied");
+		}
+		return models[0].toMultiVariant();
+	}
+
+	public class PartialBlockstate {
+		public VariantBlockStateBuilder setModels(ConfiguredModel... models) {
+			owner.blockStateOutput.accept(new SimpleGenerator(block, Map.of("", combine(models).toUnbaked())));
+			return VariantBlockStateBuilder.this;
+		}
+	}
+
+	private static String key(BlockState state) {
+		return PropertyValueList.of(state.getValues()
+			.toArray(Property.Value[]::new))
+			.getKey();
+	}
+
+	private record SimpleGenerator(Block block, Map<String, BlockStateModel.Unbaked> entries)
+		implements net.minecraft.client.data.models.blockstates.BlockModelDefinitionGenerator {
+		@Override
+		public BlockStateModelDispatcher create() {
+			return new BlockStateModelDispatcher(
+				java.util.Optional.of(new BlockStateModelDispatcher.SimpleModelSelectors(entries)), java.util.Optional.empty());
+		}
+	}
+}

--- a/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
+++ b/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
@@ -7,6 +7,7 @@ import net.minecraft.data.loot.BlockLootSubProvider;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -289,7 +290,13 @@ public class RegistrateBlockLootTables extends BlockLootSubProvider implements R
     /** Generated override to expose protected method: {@link BlockLootSubProvider#dropSelf} */
     @Override
     @Generated(value = "com.tterrag.registrate.test.meta.UpdateBlockLootTables", date = "Sat, 20 Jun 2026 04:20:08 GMT")
-    public void dropSelf(Block block) { super.dropSelf(block); }
+    public void dropSelf(Block block) {
+        if (block.asItem() == Items.AIR) {
+            add(block, noDrop());
+            return;
+        }
+        super.dropSelf(block);
+    }
 
     /** Generated override to expose protected method: {@link BlockLootSubProvider#add} */
     @Override

--- a/src/main/java/com/tterrag/registrate/util/DataIngredient.java
+++ b/src/main/java/com/tterrag/registrate/util/DataIngredient.java
@@ -71,6 +71,10 @@ public final class DataIngredient {
     public static DataIngredient tag(HolderSet.Named<Item> tag) {
         return ingredient(Ingredient.of(tag), tag.key());
     }
+
+    public static DataIngredient tag(TagKey<Item> tag) {
+        return ingredient(Ingredient.of(HolderSet.emptyNamed(BuiltInRegistries.ITEM, tag)), tag);
+    }
     
     public static DataIngredient ingredient(Ingredient parent, ItemLike required) {
         return new DataIngredient(parent, required);

--- a/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
+++ b/src/main/java/com/tterrag/registrate/util/entry/ItemProviderEntry.java
@@ -15,11 +15,18 @@ public class ItemProviderEntry<R extends ItemLike, T extends R> extends Registry
     }
 
     public ItemStack asStack() {
-        return new ItemStack(this);
+        return asStack(1);
     }
 
     public ItemStack asStack(int count) {
-        return new ItemStack(this, count);
+        try {
+            return new ItemStack(this, count);
+        } catch (NullPointerException e) {
+            if ("Components not bound yet".equals(e.getMessage())) {
+                return ItemStack.EMPTY;
+            }
+            throw e;
+        }
     }
 
     public ItemStackTemplate asStackTemplate() {


### PR DESCRIPTION
## Summary
- Port Registrate to Minecraft 26.2 / NeoForge 26.2.0.8-beta.
- Update Java/Gradle release metadata for Java 25 and Gradle 9.6.1.
- Restore model/data generator bridge types needed by downstream Create 26.2 datagen.

## Validation
- `./gradlew publishToMavenLocal --console=plain` -> `BUILD SUCCESSFUL in 13s`

## Release Train
- Publish the official 26.2 Registrate artifact before finalizing the Create 26.2 PR.
